### PR TITLE
fix(subscriptions) return active subscriptions by default

### DIFF
--- a/api-reference/subscriptions/get-all.mdx
+++ b/api-reference/subscriptions/get-all.mdx
@@ -9,7 +9,7 @@ authMethod: "bearer"
 LAGO_URL="https://api.getlago.com"
 API_KEY="__YOUR_API_KEY__"
 
-curl --location --request GET "$LAGO_URL/api/v1/subscriptions?external_customer_id=123&plan_code=starter&status[]=active" \
+curl --location --request GET "$LAGO_URL/api/v1/subscriptions?external_customer_id=123&plan_code=starter&status[]=pending" \
   --header "Authorization: Bearer $API_KEY"
 ```
 

--- a/lago-openapi.yaml
+++ b/lago-openapi.yaml
@@ -1685,7 +1685,7 @@ paths:
       tags:
         - subscriptions
       summary: List all subscriptions
-      description: This endpoint retrieves all subscriptions.
+      description: This endpoint retrieves all active subscriptions.
       operationId: findAllSubscriptions
       parameters:
         - $ref: '#/components/parameters/page'
@@ -1708,7 +1708,7 @@ paths:
             example: premium
         - name: status
           in: query
-          description: 'Filter subscriptions by status. Available filter values: `pending`, `canceled`, `terminated`, `active`.'
+          description: 'If the field is not defined, Lago will return only `active` subscriptions. However, if you wish to fetch subscriptions by different status you can define them in a status[] query param. Available filter values: `pending`, `canceled`, `terminated`, `active`.'
           required: false
           explode: true
           schema:


### PR DESCRIPTION
Update the GET /subscriptions endpoint with the correct behavior