### PR TITLE
doc(Subscription): Add overrides documentation & api ref

### DIFF
--- a/api-reference/plans/create.mdx
+++ b/api-reference/plans/create.mdx
@@ -28,7 +28,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
     "tax_codes": ["french_standard_vat"],
     "charges": [
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "api_request",
         "charge_model": "graduated",
         "invoiceable": true,
@@ -55,7 +55,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "requests",
         "charge_model": "package",
         "invoiceable": true,
@@ -71,7 +71,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "payments",
         "charge_model": "percentage",
         "invoiceable": true,
@@ -90,7 +90,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "seat",
         "charge_model": "standard",
         "invoiceable": true,
@@ -104,7 +104,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "sms_sent",
         "charge_model": "volume",
         "invoiceable": true,
@@ -131,7 +131,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "api_request_groups",
         "charge_model": "graduated",
         "invoiceable": true,
@@ -173,7 +173,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "request_groups",
         "charge_model": "package",
         "invoiceable": true,
@@ -198,7 +198,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "payment_groups",
         "charge_model": "percentage",
         "invoiceable": true,
@@ -224,7 +224,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "seats_groups",
         "charge_model": "standard",
         "invoiceable": true,
@@ -245,7 +245,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
         "tax_codes": []
       },
       {
-        "lago_billable_metric_id": "__BILLABLE_METRIC_ID__",
+        "billable_metric_id": "__BILLABLE_METRIC_ID__",
         "billable_metric_code": "sms_sent_groups",
         "charge_model": "volume",
         "invoiceable": true,

--- a/api-reference/subscriptions/assign-plan.mdx
+++ b/api-reference/subscriptions/assign-plan.mdx
@@ -10,20 +10,116 @@ authMethod: "bearer"
 LAGO_URL="https://api.getlago.com"
 API_KEY="__YOUR_API_KEY__"
 
-curl --location --request POST "$LAGO_URL/api/v1/subscriptions" \
+curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/:id" \
   --header "Authorization: Bearer $API_KEY" \
   --header 'Content-Type: application/json' \
   --data-raw '{
-    "subscription": {
-      "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
-      "plan_code": "startup_plan",
-      "external_id": "sub_id_123456789",
-      "name": "Repository A",
-      "subscription_at": "2022-08-08T00:00:00Z",
-      "ending_at": "2023-08-08T00:00:00Z",
-      "billing_time": "anniversary"
+  "subscription": {
+    "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+    "plan_code": "premium",
+    "name": "Repository A",
+    "external_id": "my_sub_1234567890",
+    "billing_time": "anniversary",
+    "ending_at": "2022-10-08T00:00:00Z",
+    "subscription_at": "2022-08-08T00:00:00Z",
+    "plan_overrides": {
+      "amount_cents": 10000,
+      "amount_currency": "USD",
+      "description": "Plan for early stage startups.",
+      "invoice_display_name": "Startup plan",
+      "name": "Startup",
+      "tax_codes": [
+        "french_standard_vat"
+      ],
+      "trial_period": 5,
+      "charges": [
+        {
+          "id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "invoice_display_name": "Setup",
+          "min_amount_cents": 0,
+          "properties": {
+            "graduated_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "flat_amount": "10",
+                "per_unit_amount": "0.5"
+              }
+            ],
+            "graduated_percentage_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "rate": "1",
+                "flat_amount": "10"
+              }
+            ],
+            "amount": "30",
+            "free_units": 100,
+            "package_size": 1000,
+            "rate": "1",
+            "fixed_amount": "0.5",
+            "free_units_per_events": 5,
+            "free_units_per_total_aggregation": "500",
+            "per_transaction_max_amount": "3.75",
+            "per_transaction_min_amount": "1.75",
+            "volume_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "flat_amount": "10",
+                "per_unit_amount": "0.5"
+              }
+            ]
+          },
+          "group_properties": [
+            {
+              "group_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+              "values": {
+                "graduated_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "flat_amount": "10",
+                    "per_unit_amount": "0.5"
+                  }
+                ],
+                "graduated_percentage_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "rate": "1",
+                    "flat_amount": "10"
+                  }
+                ],
+                "amount": "30",
+                "free_units": 100,
+                "package_size": 1000,
+                "rate": "1",
+                "fixed_amount": "0.5",
+                "free_units_per_events": 5,
+                "free_units_per_total_aggregation": "500",
+                "per_transaction_max_amount": "3.75",
+                "per_transaction_min_amount": "1.75",
+                "volume_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "flat_amount": "10",
+                    "per_unit_amount": "0.5"
+                  }
+                ]
+              }
+            }
+          ],
+          "tax_codes": [
+            "french_standard_vat"
+          ]
+        }
+      ]
     }
-  }'
+  }
+}'
 ```
 
 ```python Python

--- a/api-reference/subscriptions/assign-plan.mdx
+++ b/api-reference/subscriptions/assign-plan.mdx
@@ -10,7 +10,7 @@ authMethod: "bearer"
 LAGO_URL="https://api.getlago.com"
 API_KEY="__YOUR_API_KEY__"
 
-curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/:id" \
+curl --location --request POST "$LAGO_URL/api/v1/subscriptions/:id" \
   --header "Authorization: Bearer $API_KEY" \
   --header 'Content-Type: application/json' \
   --data-raw '{

--- a/api-reference/subscriptions/get-specific.mdx
+++ b/api-reference/subscriptions/get-specific.mdx
@@ -1,0 +1,122 @@
+---
+title: "Retrieve a subscription"
+openapi: "GET /subscriptions/{external_id}"
+authMethod: bearer
+---
+
+<RequestExample>
+
+```bash cURL
+LAGO_URL="https://api.getlago.com"
+API_KEY="__YOUR_API_KEY__"
+
+curl --location --request GET "$LAGO_URL/api/v1/subscriptions/:external_id" \
+  --header "Authorization: Bearer $API_KEY"
+```
+
+```python Python
+from lago_python_client.client import Client
+from lago_python_client.exceptions import LagoApiError
+
+client = Client(api_key='__YOUR_API_KEY__')
+
+try:
+    client.subscriptions.find('externalId')
+except LagoApiError as e:
+    repair_broken_state(e)  # do something on error or raise your own exception
+```
+
+```ruby Ruby
+require 'lago-ruby-client'
+
+client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+
+client.subscriptions.get('external_id')
+```
+
+```js Javascript
+await client.subscriptions.findSubscription('externalId')
+```
+
+```go Go
+import "fmt"
+import "github.com/getlago/lago-go-client"
+
+func main() {
+lagoClient := lago.New().
+    SetApiKey("__YOUR_API_KEY__")
+
+subscriptionResult, err := lagoClient.Subscription().Get("__YOUR_SUBSCRIPTION_EXTERNAL_ID__")
+if err != nil {
+    // Error is *lago.Error
+    panic(err)
+}
+
+// subscription is *lago.Subscription
+fmt.Println(subscription)
+}
+```
+
+```csharp C#
+using System.Collections.Generic;
+using System.Diagnostics;
+using Org.OpenAPITools.Api;
+using Org.OpenAPITools.Client;
+using Org.OpenAPITools.Model;
+
+namespace Example
+{
+  public class FindSubscriptionExample
+  {
+      public static void Main()
+      {
+          Configuration.Default.BasePath = "https://api.getlago.com/api/v1";
+          // Configure HTTP bearer authorization: bearerAuth
+          Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
+
+          var apiInstance = new SubscriptionsApi(Configuration.Default);
+          var externalId = "example_external_id";  // string | External ID of the existing subscription
+
+          try
+          {
+              // Fin subscription by external id
+              Subscription result = apiInstance.FindSubscription(externalId);
+              Debug.WriteLine(result);
+          }
+          catch (ApiException e)
+          {
+              Debug.Print("Exception when calling SubscriptionsApi.FindSubscription: " + e.Message );
+              Debug.Print("Status ExternalId: "+ e.ErrorExternalId);
+              Debug.Print(e.StackTrace);
+          }
+      }
+  }
+}
+```
+
+```php PHP
+<?php
+require_once(__DIR__ . '/vendor/autoload.php');
+
+
+// Configure Bearer authorization: bearerAuth
+$config = OpenAPI\Client\Configuration::getDefaultConfiguration()->setAccessToken('YOUR_ACCESS_TOKEN');
+
+
+$apiInstance = new OpenAPI\Client\Api\SubscriptionsApi(
+  // If you want use custom http client, pass your client which implements `GuzzleHttp\ClientInterface`.
+  // This is optional, `GuzzleHttp\Client` will be used as default.
+  new GuzzleHttp\Client(),
+  $config
+);
+$externalId = "example_external_id"; // string | External ID of the existing subscription
+
+try {
+  $result = $apiInstance->findSubscription($externalId);
+  print_r($result);
+} catch (Exception $e) {
+  echo 'Exception when calling SubscriptionsApi->findSubscription: ', $e->getMessage(), PHP_EOL;
+}
+```
+
+</RequestExample>

--- a/api-reference/subscriptions/update.mdx
+++ b/api-reference/subscriptions/update.mdx
@@ -14,12 +14,108 @@ curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/:id" \
   --header "Authorization: Bearer $API_KEY" \
   --header 'Content-Type: application/json' \
   --data-raw '{
-    "subscription": {
-      "name": "subscription_name",
-      "subscription_at": "2022-08-08T00:00:00Z",
-      "ending_at": "2023-08-08T00:00:00Z"
+  "subscription": {
+    "name": "Repository B",
+    "ending_at": "2022-10-08T00:00:00Z",
+    "subscription_at": "2022-08-08T00:00:00Z",
+    "plan_overrides": {
+      "amount_cents": 10000,
+      "amount_currency": "USD",
+      "description": "Plan for early stage startups.",
+      "invoice_display_name": "Startup plan",
+      "name": "Startup",
+      "tax_codes": [
+        "french_standard_vat"
+      ],
+      "trial_period": 5,
+      "charges": [
+        {
+          "id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+          "invoice_display_name": "Setup",
+          "min_amount_cents": 0,
+          "properties": {
+            "graduated_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "flat_amount": "10",
+                "per_unit_amount": "0.5"
+              }
+            ],
+            "graduated_percentage_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "rate": "1",
+                "flat_amount": "10"
+              }
+            ],
+            "amount": "30",
+            "free_units": 100,
+            "package_size": 1000,
+            "rate": "1",
+            "fixed_amount": "0.5",
+            "free_units_per_events": 5,
+            "free_units_per_total_aggregation": "500",
+            "per_transaction_max_amount": "3.75",
+            "per_transaction_min_amount": "1.75",
+            "volume_ranges": [
+              {
+                "from_value": 0,
+                "to_value": 10,
+                "flat_amount": "10",
+                "per_unit_amount": "0.5"
+              }
+            ]
+          },
+          "group_properties": [
+            {
+              "group_id": "1a901a90-1a90-1a90-1a90-1a901a901a90",
+              "values": {
+                "graduated_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "flat_amount": "10",
+                    "per_unit_amount": "0.5"
+                  }
+                ],
+                "graduated_percentage_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "rate": "1",
+                    "flat_amount": "10"
+                  }
+                ],
+                "amount": "30",
+                "free_units": 100,
+                "package_size": 1000,
+                "rate": "1",
+                "fixed_amount": "0.5",
+                "free_units_per_events": 5,
+                "free_units_per_total_aggregation": "500",
+                "per_transaction_max_amount": "3.75",
+                "per_transaction_min_amount": "1.75",
+                "volume_ranges": [
+                  {
+                    "from_value": 0,
+                    "to_value": 10,
+                    "flat_amount": "10",
+                    "per_unit_amount": "0.5"
+                  }
+                ]
+              }
+            }
+          ],
+          "tax_codes": [
+            "french_standard_vat"
+          ]
+        }
+      ]
     }
-  }'
+  }
+}'
 ```
 
 ```python Python

--- a/guide/subscriptions/assign-plan.mdx
+++ b/guide/subscriptions/assign-plan.mdx
@@ -202,21 +202,81 @@ When multiple subscriptions are linked to a customer, Lago will automatically co
 
 It is possible to link to the same customer subscriptions that are based on different billing cycles (e.g. a subscription based on calendar dates and another based on the anniversary date).
 
-## Overwriting a plan
-By assigning a subscription, you can use an existing plan as a template to create a new plan for your customer.
+## Overriding a plan
+By assigning a subscription to a customer, you gain the flexibility to customize certain aspects of the initially selected plan. 
+This enables you to maintain a consistent plan structure for all customers while tailoring individualized discounts through price adjustments per customer.
 
-When assigning a plan to a customer via the user interface:
-1. Select an existing plan;
-2. Click **"Overwrite"**, next to the plan name;
-3. Choose a name and a code for the new plan;
-4. Modify the plan model and charges according to your needs; and
-5. Click **"Duplicate plan"** to confirm.
+<Tabs>
+  <Tab title="Dashboard">
+  To perform a plan overrides, assign a plan to a customer and you’ll be able to make modifications to the following elements:
 
-To start a subscription, the currency of the new plan must match the currency associated with the customer.
+  1. Subscription invoice display name
+  2. Subscription fee
+  3. Plan currency
+  4. Plan trial period
+  5. Plan taxes
+  6. Charges properties (please note that the charge model cannot be modified)
+  7. Charge group definitions & properties (if applicable)
+  8. Charge minimum spending
+  9. Charge taxes
+  10. Charge invoice display name
+  </Tab>
+  <Tab title="API">
+    <CodeGroup>
+    ```bash Override a plan
+    LAGO_URL="https://api.getlago.com"
+    API_KEY="__YOUR_API_KEY__"
 
-<Info>
-Overwriting a plan has no impact on the original plan or existing subscriptions.
-</Info>
+    curl --location --request POST "$LAGO_URL/api/v1/subscriptions" \
+      --header "Authorization: Bearer $API_KEY" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+      "subscription": {
+        "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "plan_code": "premium",
+        "external_id": "my_new_sub_123456789",
+        "name": "",
+        "subscription_at": "2022-08-08T00:00:00Z",
+        "ending_at": "2023-08-08T00:00:00Z",
+        "billing_time": "anniversary",
+        "plan_overrides": {
+          "name": "new_plan",
+          "invoice_display_name": "Subscription fee",
+          "description": "Overriden plan for customer X",
+          "amount_cents": 10000,
+          "amount_currency": "USD",
+          "trial_period": "0",
+          "tax_codes": [
+            "vat_10"
+          ],
+          "charges": [
+            {
+              "id": "cac4cff7-e2d9-41e2-83e5-7947d91f0eb5",
+              "invoice_display_name": "Cards - custom price",
+              "billable_metric_code": "cards",
+              "min_amount_cents": 0,
+              "properties": {
+                "amount": "10"
+              },
+              "group_properties": [],
+              "taxes": []
+            }
+          ]
+        }
+      }
+    }'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>
+
+It's crucial to note that all overridden plans will remain associated with the initial plan but won't be visible in the plans list. 
+To access an overridden plan, simply click on the specific subscription item in the customer details view.
+
+Moreover, all invoices generated from this subscription will be based from the overridden plan, not the initial plan. 
+Additionally, any coupons restricted to a plan code will apply to both the initial and overridden plans.
+
+Importantly, any changes made to the initial plans will not impact the subscriptions linked to overridden plans.
 
 ## Deleting a plan
 You could [delete a plan](/api-reference/plans/destroy) linked to existing subscriptions.

--- a/guide/subscriptions/assign-plan.mdx
+++ b/guide/subscriptions/assign-plan.mdx
@@ -203,6 +203,17 @@ When multiple subscriptions are linked to a customer, Lago will automatically co
 It is possible to link to the same customer subscriptions that are based on different billing cycles (e.g. a subscription based on calendar dates and another based on the anniversary date).
 
 ## Overriding a plan
+
+<Info>
+
+**PREMIUM FEATURE** ✨
+
+This feature is only available to users with a premium license. Please
+**[contact us](mailto:hello@getlago.com)** to get access to Lago Cloud and Lago
+Self-Hosted Premium.
+
+</Info>
+
 By assigning a subscription to a customer, you gain the flexibility to customize certain aspects of the initially selected plan. 
 This enables you to maintain a consistent plan structure for all customers while tailoring individualized discounts through price adjustments per customer.
 

--- a/guide/subscriptions/edit-subscription.mdx
+++ b/guide/subscriptions/edit-subscription.mdx
@@ -1,0 +1,51 @@
+---
+title: "Edit a subscription"
+description: "You can edit a subscription at any time, whether it's active or pending."
+---
+
+Once a plan has been assigned to a customer, whether it's in a pending or active state, you can make edits to the subscription by following these steps:
+
+<Tabs>
+  <Tab title="Dashboard">
+  1. Click on the three dots menu icon and select "Edit subscription."
+  2. Subscription Start and End Date   
+  You have the ability to modify the subscription start date if the subscription is pending, and if the chosen date is later than today. It's important to refer to the [guidelines for subscription start date](https://docs.getlago.com/guide/subscriptions/assign-plan#subscription-start-date) for further information.  
+  3. Subscription End Date   
+  You can also make changes to the subscription end date, but it's important to refer to the [guidelines for subscription end date](https://docs.getlago.com/guide/subscriptions/assign-plan#subscription-end-date) for further information.
+  4. Only usage-based charge properties & group properties can be edited.
+  </Tab>
+  <Tab title="API">
+    <CodeGroup>
+    ```bash Override a plan
+    LAGO_URL="https://api.getlago.com"
+    API_KEY="__YOUR_API_KEY__"
+    
+    curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/{external_id}" \
+      --header "Authorization: Bearer $API_KEY" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+      "subscription": {
+        "name": "",
+        "subscription_at": "2022-08-08T00:00:00Z",
+        "ending_at": "2023-08-08T00:00:00Z",
+        "plan_overrides": {
+          "name": "new_plan",
+          "invoice_display_name": "Subscription fee",
+          "description": "Overriden plan for customer X",
+          "charges": [
+            {
+              "id": "cac4cff7-e2d9-41e2-83e5-7947d91f0eb5",
+              "invoice_display_name": "Cards - custom price",
+              "properties": {
+                "amount": "10"
+              },
+              "group_properties": [],
+            }
+          ]
+        }
+      }
+    }'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>

--- a/guide/subscriptions/edit-subscription.mdx
+++ b/guide/subscriptions/edit-subscription.mdx
@@ -12,7 +12,7 @@ Once a plan has been assigned to a customer, whether it's in a pending or active
   You have the ability to modify the subscription start date if the subscription is pending, and if the chosen date is later than today. It's important to refer to the [guidelines for subscription start date](https://docs.getlago.com/guide/subscriptions/assign-plan#subscription-start-date) for further information.  
   3. Subscription End Date   
   You can also make changes to the subscription end date, but it's important to refer to the [guidelines for subscription end date](https://docs.getlago.com/guide/subscriptions/assign-plan#subscription-end-date) for further information.
-  4. Only usage-based charge properties & group properties can be edited.
+  4. Only usage-based charge properties & group properties can be edited (Only for premium user)
   </Tab>
   <Tab title="API">
     <CodeGroup>

--- a/lago-openapi.yaml
+++ b/lago-openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lago API documentation
   description: Lago API allows your application to push customer information and metrics (events) from your application to the billing application.
-  version: 0.48.0-beta
+  version: 0.49.0-beta
   license:
     name: AGPLv3
   contact:
@@ -1075,7 +1075,7 @@ paths:
         - $ref: '#/components/parameters/external_subscription_id'
         - name: currency
           in: query
-          description: Filter results by fee’s currency.
+          description: Filter results by feeâ€™s currency.
           required: false
           explode: true
           schema:
@@ -1204,7 +1204,7 @@ paths:
     parameters:
       - name: lago_id
         in: path
-        description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the fee’s record within the Lago system.
+        description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the feeâ€™s record within the Lago system.
         required: true
         schema:
           type: string
@@ -1971,7 +1971,7 @@ paths:
     parameters:
       - name: lago_id
         in: path
-        description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet’s record within the Lago system.
+        description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the walletâ€™s record within the Lago system.
         required: true
         schema:
           type: string
@@ -2078,7 +2078,7 @@ paths:
       parameters:
         - name: lago_id
           in: path
-          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet’s record within the Lago system.
+          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the walletâ€™s record within the Lago system.
           required: true
           schema:
             type: string
@@ -2272,7 +2272,7 @@ components:
     lago_invoice_id:
       name: lago_id
       in: path
-      description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoice’s record within the Lago system.
+      description: Unique identifier assigned to the invoice within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the invoiceâ€™s record within the Lago system.
       required: true
       schema:
         type: string
@@ -3729,7 +3729,7 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the credit within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the credit’s item record within the Lago system.
+          description: Unique identifier assigned to the credit within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the creditâ€™s item record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         amount_cents:
           type: integer
@@ -3821,16 +3821,16 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: 'The credit note’s item unique identifier, created by Lago.'
+          description: 'The credit noteâ€™s item unique identifier, created by Lago.'
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         amount_cents:
           type: integer
-          description: 'The credit note’s item amount, expressed in cents.'
+          description: 'The credit noteâ€™s item amount, expressed in cents.'
           example: 100
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: The credit note’s item currency.
+            - description: The credit noteâ€™s item currency.
               example: EUR
         fee:
           allOf:
@@ -3987,7 +3987,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CreditNoteItemObject'
-          description: Array of credit note’s items.
+          description: Array of credit noteâ€™s items.
         applied_taxes:
           type: array
           items:
@@ -4062,7 +4062,7 @@ components:
                     type: integer
                     description: 'The amount of the credit note item, expressed in cents.'
                     example: 10
-              description: The list of credit note’s items.
+              description: The list of credit noteâ€™s items.
               example:
                 - fee_id: 1a901a90-1a90-1a90-1a90-1a901a901a90
                   amount_cents: 10
@@ -4322,7 +4322,7 @@ components:
               type: string
               format: uuid
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-              description: Unique identifier assigned to the charge within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the charge’s record within the Lago system.
+              description: Unique identifier assigned to the charge within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the chargeâ€™s record within the Lago system.
             charge_model:
               type: string
               description: 'The pricing model applied to this charge. Possible values are standard, `graduated`, `percentage`, `package` or `volume`.'
@@ -4346,7 +4346,7 @@ components:
               type: string
               format: uuid
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-              description: Unique identifier assigned to the billable metric within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the billable metric’s record within the Lago system.
+              description: Unique identifier assigned to the billable metric within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the billable metricâ€™s record within the Lago system.
             name:
               type: string
               example: Storage
@@ -4787,7 +4787,7 @@ components:
         currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: The currency of the customer’s current usage.
+            - description: The currency of the customerâ€™s current usage.
               example: EUR
         amount_cents:
           type: integer
@@ -4988,7 +4988,7 @@ components:
           type: string
           format: uuid
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: Unique identifier assigned to the subscription within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the subscription’s record within the Lago system
+          description: Unique identifier assigned to the subscription within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the subscriptionâ€™s record within the Lago system
         external_subscription_id:
           type: string
           example: sub_1234567890
@@ -5035,7 +5035,7 @@ components:
           type: string
           format: uuid
           nullable: true
-          description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the fee’s record within the Lago system.
+          description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the feeâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         lago_group_id:
           type: string
@@ -5094,7 +5094,7 @@ components:
         amount_currency:
           allOf:
             - $ref: '#/components/schemas/Currency'
-            - description: The currency of this specific fee. It indicates the monetary unit in which the fee’s cost is expressed.
+            - description: The currency of this specific fee. It indicates the monetary unit in which the feeâ€™s cost is expressed.
               example: EUR
         taxes_amount_cents:
           type: integer
@@ -5348,11 +5348,11 @@ components:
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         key:
           type: string
-          description: Represents the key of the metadata’s key-value pair.
+          description: Represents the key of the metadataâ€™s key-value pair.
           example: digital_ref_id
         value:
           type: string
-          description: Represents the value of the metadata’s key-value pair.
+          description: Represents the value of the metadataâ€™s key-value pair.
           example: INV-0123456-98765
         created_at:
           type: string
@@ -5383,7 +5383,7 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the fee’s record within the Lago system.
+          description: Unique identifier assigned to the fee within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the feeâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         sequential_id:
           type: integer
@@ -5645,7 +5645,7 @@ components:
         invoice_grace_period:
           type: integer
           example: 3
-          description: 'The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customer’s grace period.'
+          description: 'The grace period, expressed in days, for finalizing the invoice. This period refers to the additional time granted to your customers beyond the invoice due date to adjust usage and line items. Can be overwritten by the customerâ€™s grace period.'
         document_locale:
           type: string
           example: en
@@ -5697,22 +5697,22 @@ components:
         address_line1:
           type: string
           example: 100 Brex Street
-          description: The first line of your organization’s billing address.
+          description: The first line of your organizationâ€™s billing address.
           nullable: true
         address_line2:
           type: string
           example: null
-          description: The second line of your organization’s billing address.
+          description: The second line of your organizationâ€™s billing address.
           nullable: true
         state:
           type: string
           example: NYC
-          description: The state of your organization’s billing address.
+          description: The state of your organizationâ€™s billing address.
           nullable: true
         zipcode:
           type: string
           example: '10000'
-          description: The zipcode of your organization’s billing address.
+          description: The zipcode of your organizationâ€™s billing address.
           nullable: true
         email:
           type: string
@@ -5723,7 +5723,7 @@ components:
         city:
           type: string
           example: New York
-          description: The city of your organization’s billing address.
+          description: The city of your organizationâ€™s billing address.
           nullable: true
         legal_name:
           type: string
@@ -5747,7 +5747,7 @@ components:
         timezone:
           allOf:
             - $ref: '#/components/schemas/Timezone'
-            - description: 'Your organization’s timezone, used for billing purposes in your own local time. Can be overwritten by the customer’s timezone.'
+            - description: 'Your organizationâ€™s timezone, used for billing purposes in your own local time. Can be overwritten by the customerâ€™s timezone.'
               example: America/New_York
         billing_configuration:
           $ref: '#/components/schemas/OrganizationBillingConfiguration'
@@ -5778,22 +5778,22 @@ components:
             address_line1:
               type: string
               example: 100 Brex Street
-              description: The first line of your organization’s billing address.
+              description: The first line of your organizationâ€™s billing address.
               nullable: true
             address_line2:
               type: string
               example: null
-              description: The second line of your organization’s billing address.
+              description: The second line of your organizationâ€™s billing address.
               nullable: true
             state:
               type: string
               example: NYC
-              description: The state of your organization’s billing address.
+              description: The state of your organizationâ€™s billing address.
               nullable: true
             zipcode:
               type: string
               example: '10000'
-              description: The zipcode of your organization’s billing address.
+              description: The zipcode of your organizationâ€™s billing address.
               nullable: true
             email:
               type: string
@@ -5804,7 +5804,7 @@ components:
             city:
               type: string
               example: New York
-              description: The city of your organization’s billing address.
+              description: The city of your organizationâ€™s billing address.
               nullable: true
             legal_name:
               type: string
@@ -5828,7 +5828,7 @@ components:
             timezone:
               allOf:
                 - $ref: '#/components/schemas/Timezone'
-                - description: 'Your organization’s timezone, used for billing purposes in your own local time. Can be overwritten by the customer’s timezone.'
+                - description: 'Your organizationâ€™s timezone, used for billing purposes in your own local time. Can be overwritten by the customerâ€™s timezone.'
                   example: America/New_York
             email_settings:
               type: array
@@ -5931,7 +5931,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan’s interval is `yearly`.'
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the planâ€™s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -6101,6 +6101,89 @@ components:
                     free_units_per_events: 5
                     free_units_per_total_aggregation: '500'
                   group_properties: []
+    PlanOverridesObject:
+      type: object
+      description: Based plan overrides.
+      properties:
+        amount_cents:
+          type: integer
+          description: 'The base cost of the plan, excluding any applicable taxes, that is billed on a recurring basis. This value is defined at 0 if your plan is a pay-as-you-go plan.'
+          example: 10000
+        amount_currency:
+          allOf:
+            - $ref: '#/components/schemas/Currency'
+            - description: 'The currency of the plan. It indicates the monetary unit in which the plan''s cost, including taxes and usage-based charges, is expressed.'
+              example: USD
+        description:
+          type: string
+          description: The description on the plan.
+          example: Plan for early stage startups.
+        invoice_display_name:
+          type: string
+          example: Startup plan
+          description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the plan will be used as the default display name.'
+        name:
+          type: string
+          example: Startup
+          description: The name of the plan.
+        tax_codes:
+          type: array
+          items:
+            type: string
+          description: List of unique code used to identify the taxes.
+          example:
+            - french_standard_vat
+        trial_period:
+          type: number
+          description: The duration in days during which the base cost of the plan is offered for free.
+          example: 5
+        charges:
+          type: array
+          description: Additional usage-based charges for this plan.
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+                description: Unique identifier of the charge created by Lago.
+                example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+              invoice_display_name:
+                type: string
+                description: 'Specifies the name that will be displayed on an invoice. If no value is set for this field, the name of the actual charge will be used as the default display name.'
+                example: Setup
+              min_amount_cents:
+                type: integer
+                description: 'The minimum spending amount required for the charge, measured in cents and excluding any applicable taxes. It indicates the minimum amount that needs to be charged for each billing period.'
+                example: 0
+              properties:
+                allOf:
+                  - $ref: '#/components/schemas/ChargeProperties'
+                  - description: List of all thresholds utilized for calculating the charge.
+              group_properties:
+                type: array
+                description: 'All charge information, sorted by groups.'
+                items:
+                  type: object
+                  required:
+                    - group_id
+                    - values
+                  properties:
+                    group_id:
+                      type: string
+                      description: 'Unique identifier of a billable metric group, created by Lago.'
+                      example: 1a901a90-1a90-1a90-1a90-1a901a901a90
+                    values:
+                      allOf:
+                        - $ref: '#/components/schemas/ChargeProperties'
+                        - description: 'List of all thresholds utilized for calculating a charge, scoped by groups used as dimensions for a single charge.'
+              tax_codes:
+                type: array
+                items:
+                  type: string
+                description: List of unique code used to identify the taxes.
+                example:
+                  - french_standard_vat
     PlanUpdateInput:
       type: object
       required:
@@ -6153,7 +6236,7 @@ components:
               example: true
             bill_charges_monthly:
               type: boolean
-              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan’s interval is `yearly`.'
+              description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the planâ€™s interval is `yearly`.'
               nullable: true
               example: null
             tax_codes:
@@ -6396,7 +6479,7 @@ components:
         bill_charges_monthly:
           type: boolean
           nullable: true
-          description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the plan’s interval is `yearly`.'
+          description: 'This field, when set to `true`, enables to invoice usage-based charges on monthly basis, even if the cadence of the plan is yearly. This allows customers to pay charges overage on a monthly basis. This can be set to true only if the planâ€™s interval is `yearly`.'
           example: null
         active_subscriptions_count:
           type: integer
@@ -6578,6 +6661,8 @@ components:
               format: date-time
               example: '2022-08-08T00:00:00Z'
               description: 'The start date for the subscription, allowing for the creation of subscriptions that can begin in the past or future. Please note that it cannot be used to update the start date of a pending subscription or schedule an upgrade/downgrade. The start_date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).'
+            plan_overrides:
+              $ref: '#/components/schemas/PlanOverridesObject'
     SubscriptionUpdateInput:
       type: object
       required:
@@ -6601,6 +6686,8 @@ components:
               format: date-time
               example: '2022-08-08T00:00:00Z'
               description: The start date and time of the subscription. This field can only be modified for pending subscriptions that have not yet started. This date should be provided in ISO 8601 datetime format and expressed in Coordinated Universal Time (UTC).
+            plan_overrides:
+              $ref: '#/components/schemas/PlanOverridesObject'
     SubscriptionObject:
       type: object
       required:
@@ -6618,7 +6705,7 @@ components:
           type: string
           format: uuid
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
-          description: Unique identifier assigned to the subscription within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the subscription’s record within the Lago system
+          description: Unique identifier assigned to the subscription within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the subscriptionâ€™s record within the Lago system
         external_id:
           type: string
           example: 5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba
@@ -7054,12 +7141,12 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet’s record within the Lago system.
+          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the walletâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         lago_customer_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the customer within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the customer’s record within the Lago system.
+          description: Unique identifier assigned to the customer within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the customerâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         external_customer_id:
           type: string
@@ -7154,7 +7241,7 @@ components:
             wallet_id:
               type: string
               format: uuid
-              description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet’s record within the Lago system.
+              description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the walletâ€™s record within the Lago system.
               example: 1a901a90-1a90-1a90-1a90-1a901a901a90
             paid_credits:
               type: string
@@ -7180,12 +7267,12 @@ components:
         lago_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the wallet transaction within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet transaction’s record within the Lago system.
+          description: Unique identifier assigned to the wallet transaction within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet transactionâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         lago_wallet_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the wallet’s record within the Lago system.
+          description: Unique identifier assigned to the wallet within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the walletâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         status:
           type: string
@@ -7301,7 +7388,7 @@ components:
         lago_organization_id:
           type: string
           format: uuid
-          description: Unique identifier assigned to the organization attached to the webhook endpoint within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the organization’s record within the Lago system.
+          description: Unique identifier assigned to the organization attached to the webhook endpoint within the Lago application. This ID is exclusively created by Lago and serves as a unique identifier for the organizationâ€™s record within the Lago system.
           example: 1a901a90-1a90-1a90-1a90-1a901a901a90
         webhook_url:
           type: string

--- a/mint.json
+++ b/mint.json
@@ -132,7 +132,8 @@
           "group": "Subscriptions",
           "pages": [
             "guide/subscriptions/assign-plan", 
-            "guide/subscriptions/upgrades-downgrades", 
+            "guide/subscriptions/upgrades-downgrades",
+            "guide/subscriptions/edit-subscription", 
             "guide/subscriptions/terminate-subscription"
           ]
         },
@@ -225,6 +226,7 @@
             "api-reference/subscriptions/assign-plan",
             "api-reference/subscriptions/terminate",
             "api-reference/subscriptions/update",
+            "api-reference/subscriptions/get-specific",
             "api-reference/subscriptions/get-all"
           ]
         },


### PR DESCRIPTION
## Description

Documentation regarding Overrides plan when creating a subscription.
It should impact the documentation guide (`assign a plan` & `edit a subscription`)
It should impact the API ref (`POST /subscription` & `PUT /subscription` & `POST /subscription/{external_id`)
+
Impact `POST /plans` with a correction regarding `lago_billable_metric_id` to `billable_metric_id`