### PR TITLE
doc(Locales): Add Spanish and Swedish in documentation

### DIFF
--- a/api-reference/resources/locales.mdx
+++ b/api-reference/resources/locales.mdx
@@ -2,15 +2,19 @@
 title: "Document locales"
 ---
 
+## Document locales supported
+
 List of accepted locales for documents (ISO 639-1).
 
-| Code | Document language |
+| Document language | Code | 
 |--|--|
-| `de` | German |
-| `en` | English |
-| `fr` | French |
-| `it` | Italian |
-| `nb` | Norwegian (Bokmål) |
+| German | `de` |
+| English | `en` |
+| French | `fr` |
+| Italian | `it` |
+| Norwegian (Bokmål) | `nb` |
+| Spanish | `es` |
+| Swedish | `sv` |
 
 ## How to add a new language
 
@@ -27,7 +31,7 @@ The names of your billable metrics, plans, add-ons, coupons and wallets are defi
 </Info>
 
 To add a new language:
-1. [Download the document template](https://uploads-ssl.webflow.com/635119506e36baf5c267fecd/651ed8db3362f026c5aa6c98_locales-doc-template.pdf) to see where each key is located;
+1. [Download the document template](https://uploads-ssl.webflow.com/635119506e36baf5c267fecd/6527de427c3e29ca959e6f0a_locales-doc-template.pdf) to see where each key is located;
 2. Use the text file below to provide translations for the new language; and
 3. Send the new text file to [hello@getlago.com](mailto:hello@getlago.com), so that we can review it and add it to the codebase.
 
@@ -111,7 +115,7 @@ en:
     [1.11] unit: "Unit"
     [1.12] unit_price: "Unit price"
     [1.13] tax_rate: "Tax rate"
-    [1.14] amount: "Amount (excl. tax)"
+    [1.14] amount: "Amount"
     [1.15] sub_total_without_tax: "Sub total (excl. tax)"
     [1.16] tax_name: "%{name} (%{rate}% on %{amount})"
     [1.17] sub_total_with_tax: "Sub total (incl. tax)"
@@ -161,6 +165,8 @@ en:
     see_breakdown: "See breakdown below"
     total_unit_interval: "Total number of units: %{events_count} event(s) for %{units}"
     total_unit: "Total number of units: %{units}"
+    amount_with_tax: "Amount (incl. tax)"
+    amount_without_tax: "Amount (excl. tax)"
     
 
 =====================================================================
@@ -233,8 +239,8 @@ en:
     [7.6] legal_name_not_provided: "Legal name not provided"
     [7.7] legal_number: "Legal number"
     [7.8] legal_number_not_provided: "Legal number not provided"
-    [7.9] payment_provider: "Payment provider"
-    [7.10] payment_provider_not_provided: "Payment provider not provided"
+    [7.9] tax_id: "Tax ID number"
+    [7.10] tax_id_not_provided: "Tax ID number not provided"
     [7.11] email: "Email"
     [7.12] email_not_provided: "Email not provided"
     [7.13] address: "Address"
@@ -251,4 +257,9 @@ en:
     [7.24] invoices_empty_state: "There are currently no invoices attached to this customer. Please check back later, or contact us if you notice any issues."
     [7.25] expired_customer_portal_header: "For security reasons, this page has expired"
     [7.26] error_customer_portal_header: "Something went wrong token is invalid or has expired"
+    [7.27] something_went_wrong: "Something went wrong"
+    [7.28] please_refresh: "Please refresh the page or contact us if the error persists."
+    [7.29] refresh: "Refresh the page"
+    [7.30] not_found: "This invoice cannot be found"
+    [7.31] change_keyword: "Could you enter another keyword?"
 ```


### PR DESCRIPTION
## Description
Adding Spanish and Swedish in the list of document locales supported by Lago