### PR TITLE
fix 404s + missing s to http links

### DIFF
--- a/faq/about-software.mdx
+++ b/faq/about-software.mdx
@@ -9,7 +9,7 @@ Lago is the most popular open-source repository solving for billing on Github, t
 It has been chosen by companies like:
 
 - [Pennylane](https://www.pennylane.com/) – the best Quickbooks alternative for SMBs, backed by Sequoia Capital.
-- [Swan](http://swan.io) – the leading European Banking-as-a-Service (BaaS), backed by Accel and Creandum.
+- [Swan](https://swan.io) – the leading European Banking-as-a-Service (BaaS), backed by Accel and Creandum.
 - [Flipside Crypto](https://flipsidecrypto.xyz/) – a leading provider of on-demand analytics and business intelligence for blockchain, backed by CoinBase Ventures.
 
 and many more.

--- a/guide/lago-open-api.mdx
+++ b/guide/lago-open-api.mdx
@@ -9,7 +9,7 @@ Using our Open API is a great way to explore and interact with Lago's API docume
 Before you start using our Open API, here are some important prerequisites and useful links:
 
 1. Create a free [Postman](https://postman.com) account;
-2. Use the [Swagger](http://swagger.getlago.com/) for Lago's API documentation;
+2. Use the [Swagger](https://swagger.getlago.com/) for Lago's API documentation;
 3. Open a Lago account to get your API key; and
 4. Check out our public [GitHub repository](https://github.com/getlago/lago-openapi).
 
@@ -17,7 +17,7 @@ Before you start using our Open API, here are some important prerequisites and u
 
 The Swagger used to document Lago's API can be imported directly into Postman. To do so: 
 
-1. **Copy the following link:** [http://swagger.getlago.com/openapi.yaml](http://swagger.getlago.com/openapi.yaml) (this link can also be found on the Swagger's page);
+1. **Copy the following link:** [https://swagger.getlago.com/openapi.yaml](https://swagger.getlago.com/openapi.yaml) (this link can also be found on the Swagger's page);
 2. In Postman, under **Import > Link**, paste the URL above;
 3. Click **Continue**;
 4. Click the **Import** button; and

--- a/integrations/crm/salesforce-crm.mdx
+++ b/integrations/crm/salesforce-crm.mdx
@@ -123,8 +123,8 @@ To establish a connection between your Lago instance and the Salesforce Package,
 2. Find and open the Lago app you recently installed;
 3. Within the Lago Base Configuration tab:
   - Provide your **Lago API Key** (located in Lago's Developer Section)
-  - Enter your Lago **API base URL**. Do not insert the `api/v1` at the end of the URL. By default, the valid URL is https://api.getlago.com/. 
-  If you want to change the API base URL to another one (e.g., https://api.eu.getlago.com/ or a custom self-hosted one), please follow this [guide](#configure-your-custom-api-base-url).
+  - Enter your Lago **API base URL**. Do not insert the `api/v1` at the end of the URL. By default, the valid URL is `https://api.getlago.com/`. 
+  If you want to change the API base URL to another one (e.g., `https://api.eu.getlago.com/` or a custom self-hosted one), please follow this [guide](#configure-your-custom-api-base-url).
 4. **"Save and validate"** your connection; and
 5. Click the **"Start Sync Data"** to finalize the connection between Lago and Salesforce.
 


### PR DESCRIPTION
Hello guys 👋

It seems like Mintlify is transforming plain text urls into links. This is bad for SEO as we are linking to 404s.
In the future, could you try to put urls inside quotes to prevent this behaviour?

Thank you 🙌