### PR TITLE
Remove broken GoCardless link

### DIFF
--- a/guide/payments/gocardless-integration.mdx
+++ b/guide/payments/gocardless-integration.mdx
@@ -43,7 +43,7 @@ via GoCardless, you must create a webhook endpoint in GoCardless. To do so:
 2. Go to the **"Developers"** section;
 3. In the upper right corner, click **"Create"** and then select **"Webhook endpoint"**;
 4. Choose a name for this webhook (e.g. Lago);
-5. Enter the following URL:[https://api.getlago.com/webhook/gocardless/{id}](https://api.getlago.com/webhook/gocardless/{id}) (you must replace `{id}` with your Lago organization ID);
+5. Enter the following URL: `https://api.getlago.com/webhook/gocardless/{id}` (you must replace `{id}` with your Lago organization ID);
 6. Enter your secret key; and
 7. Click **"Create webhook endpoint"**.
 


### PR DESCRIPTION
Hello team,

removing one last 404 link.
Bonus: the content was actually broken because the `{id}` part would not show up. See the screenshot attached.

<img src="https://github.com/getlago/lago-doc/assets/16031781/feafa681-0439-4e14-8b2c-52f8f5ddf2d7" width="600">
