### PR TITLE
misc(js) turn all attributes into camel_case notation

### DIFF
--- a/api-reference/add-ons/create.mdx
+++ b/api-reference/add-ons/create.mdx
@@ -3,7 +3,6 @@ openapi: "POST /add_ons"
 authMethod: "bearer"
 ---
 
-
 <RequestExample>
 
 ```bash cURL
@@ -69,9 +68,9 @@ const addOnObject = {
   name: "Setup Fee",
   code: "setup_fee",
   description: "Implementation fee for new customers.",
-  amountCents: 50000,
-  amountCurrency: "USD",
-  taxCodes: ["french_standard_vat"]
+  amount_cents: 50000,
+  amount_currency: "USD",
+  tax_codes: ["french_standard_vat"],
 };
 
 await client.addOns.createAddOn({ addOn: addOnObject });

--- a/api-reference/add-ons/get-all.mdx
+++ b/api-reference/add-ons/get-all.mdx
@@ -34,7 +34,7 @@ client.add_ons.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.addOns.findAllAddOns({ perPage: 2, page: 3 });
+await client.addOns.findAllAddOns({ per_page: 2, page: 3 });
 ```
 
 ```go Go

--- a/api-reference/add-ons/update.mdx
+++ b/api-reference/add-ons/update.mdx
@@ -3,7 +3,6 @@ openapi: "PUT /add_ons/{code}"
 authMethod: "bearer"
 ---
 
-
 <RequestExample>
 
 ```bash cURL
@@ -50,7 +49,7 @@ client.add_ons.update(update_params, 'setup_fee')
 
 ```js Javascript
 await client.addOns.updateAddOn("code", {
-  addOn: { name: "Setup Fee", code: "setup_fee" },
+  add_on: { name: "Setup Fee", code: "setup_fee" },
 });
 ```
 

--- a/api-reference/billable-metrics/create.mdx
+++ b/api-reference/billable-metrics/create.mdx
@@ -83,10 +83,10 @@ await client.billableMetrics.createBillableMetric({
   billable_metric: {
     name: "Storage",
     code: "storage",
-    aggregationType: "sum_agg",
+    aggregation_type: "sum_agg",
     recurring: false,
-    fieldName: "gb",
-    weightedInterval: 'seconds',
+    field_name: "gb",
+    weighted_interval: "seconds",
     group: {
       key: "region",
       values: ["us-east-1", "us-east-2", "eu-west-1"],

--- a/api-reference/billable-metrics/get-all-groups.mdx
+++ b/api-reference/billable-metrics/get-all-groups.mdx
@@ -2,6 +2,7 @@
 openapi: "GET /billable_metrics/{code}/groups"
 authMethod: "bearer"
 ---
+
 <RequestExample>
 
 ```bash cURL
@@ -35,7 +36,7 @@ client.groups.get_all('billable_metric_code', { per_page: 2, page: 3 })
 ```js Javascript
 await client.billableMetrics.findAllBillableMetricGroups(
   "billable_metric_code",
-  { perPage: 2, page: 3 }
+  { per_page: 2, page: 3 }
 );
 ```
 
@@ -83,8 +84,8 @@ namespace Example
 
           var apiInstance = new BillableMetricsApi(Configuration.Default);
           var code = "example_code";  // string | Code of the existing billable metric
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {

--- a/api-reference/billable-metrics/get-all.mdx
+++ b/api-reference/billable-metrics/get-all.mdx
@@ -34,7 +34,7 @@ client.billable_metrics.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.billableMetrics.findAllBillableMetrics({ perPage: 2, page: 3 });
+await client.billableMetrics.findAllBillableMetrics({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -79,8 +79,8 @@ public class FindAllBillableMetricsExample
         Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
         var apiInstance = new BillableMetricsApi(Configuration.Default);
-        var page = 2;  // int? | Number of page (optional) 
-        var perPage = 20;  // int? | Number of records per page (optional) 
+        var page = 2;  // int? | Number of page (optional)
+        var perPage = 20;  // int? | Number of records per page (optional)
 
         try
         {

--- a/api-reference/billable-metrics/update.mdx
+++ b/api-reference/billable-metrics/update.mdx
@@ -84,9 +84,9 @@ const newBillableMetricObject = {
   name: "Storage",
   code: "storage",
   recurring: false,
-  aggregationType: "sum_agg",
-  weightedInterval: "seconds",
-  fieldName: "gb",
+  aggregation_type: "sum_agg",
+  weighted_interval: "seconds",
+  field_name: "gb",
 };
 
 await client.billableMetrics.updateBillableMetric("code", {

--- a/api-reference/coupons/apply.mdx
+++ b/api-reference/coupons/apply.mdx
@@ -64,12 +64,12 @@ client.applied_coupons.create(
 
 ```js Javascript
 const appliedCouponObject = {
-  externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
-  couponCode: "startup_deal",
-  amountCents: 2500,
-  amountCurrency: "EUR",
+  external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+  coupon_code: "startup_deal",
+  amount_cents: 2500,
+  amount_currency: "EUR",
   frequency: "recurring" as AppliedCouponObject["frequency"],
-  frequencyDuration: 3,
+  frequency_duration: 3,
 };
 
 await client.appliedCoupons.applyCoupon({

--- a/api-reference/coupons/create.mdx
+++ b/api-reference/coupons/create.mdx
@@ -88,15 +88,15 @@ const couponObject = {
   name: "Startup Deal",
   code: "startup_deal",
   expiration: "time_limit" as CouponObject["expiration"],
-  expirationAt: "2022-08-08T23:59:59Z",
-  amountCents: 5000,
-  amountCurrency: "USD",
-  couponType: "fixed_amount" as CouponObject["couponType"],
+  expiration_at: "2022-08-08T23:59:59Z",
+  amount_cents: 5000,
+  amount_currency: "USD",
+  coupon_type: "fixed_amount" as CouponObject["couponType"],
   reusable: true,
   frequency: "recurring" as CouponObject["frequency"],
-  frequencyDuration: 6,
-  appliesTo: {
-    planCodes: ["startup_plan"],
+  frequency_duration: 6,
+  applies_to: {
+    plan_codes: ["startup_plan"],
   },
 };
 

--- a/api-reference/coupons/get-all-applied.mdx
+++ b/api-reference/coupons/get-all-applied.mdx
@@ -34,7 +34,7 @@ client.applied_coupons.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.appliedCoupons.findAllAppliedCoupons({ perPage: 2, page: 3 });
+await client.appliedCoupons.findAllAppliedCoupons({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -130,4 +130,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/coupons/get-all.mdx
+++ b/api-reference/coupons/get-all.mdx
@@ -34,7 +34,7 @@ client.coupons.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.coupons.findAllCoupons({ perPage: 2, page: 3 });
+await client.coupons.findAllCoupons({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -79,8 +79,8 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new CouponsApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {

--- a/api-reference/credit-notes/create.mdx
+++ b/api-reference/credit-notes/create.mdx
@@ -91,18 +91,18 @@ client.credit_notes.create(credit_note)
 import { CreditNoteObject } from "lago-javascript-client";
 
 const creditNoteObject = {
-  invoiceId: "__LAGO_INVOICE_ID__",
+  invoice_id: "__LAGO_INVOICE_ID__",
   reason: "other" as CreditNoteObject["reason"],
-  creditAmountCents: 10,
-  refundAmountCents: 5,
+  credit_amount_cents: 10,
+  refund_amount_cents: 5,
   items: [
     {
-      feeId: "__LAGO_FEE_ID__",
-      amountCents: 10,
+      fee_id: "__LAGO_FEE_ID__",
+      amount_cents: 10,
     },
     {
-      feeId: "__LAGO_FEE_ID__",
-      amountCents: 5,
+      fee_id: "__LAGO_FEE_ID__",
+      amount_cents: 5,
     },
   ],
 };

--- a/api-reference/credit-notes/get-all.mdx
+++ b/api-reference/credit-notes/get-all.mdx
@@ -34,7 +34,7 @@ client.credit_notes.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.creditNotes.findAllCreditNotes({ perPage: 2, page: 3 });
+await client.creditNotes.findAllCreditNotes({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -79,9 +79,9 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new CreditNotesApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
-          var externalCustomerId = "12345";  // string | External customer ID (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
+          var externalCustomerId = "12345";  // string | External customer ID (optional)
 
           try
           {

--- a/api-reference/credit-notes/update.mdx
+++ b/api-reference/credit-notes/update.mdx
@@ -46,8 +46,8 @@ client.credit_note.update(
 
 ```js Javascript
 await client.creditNotes.updateCreditNote("credit-note-id", {
-  creditNote: {
-    refundStatus: "pending",
+  credit_note: {
+    refund_status: "pending",
   },
 });
 ```

--- a/api-reference/customers/create.mdx
+++ b/api-reference/customers/create.mdx
@@ -147,36 +147,36 @@ client.customers.create(
 import { BillingConfigurationCustomer } from "lago-javascript-client";
 
 const customerObject = {
-  externalId: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
-  addressLine1: "5230 Penfield Ave",
+  external_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+  address_line1: "5230 Penfield Ave",
   city: "Woodland Hills",
   currency: "EUR",
   country: "US",
   email: "dinesh@piedpiper.test",
-  legalName: "Coleman-Blair",
-  legalNumber: "49-008-2965",
-  taxIdentificationNumber: "EU123456789",
-  logoUrl: "http://hooli.com/logo.png",
+  legal_name: "Coleman-Blair",
+  legal_number: "49-008-2965",
+  tax_identification_number: "EU123456789",
+  logo_url: "http://hooli.com/logo.png",
   name: "Gavin Belson",
   phone: "1-171-883-3711 x245",
   state: "CA",
   timezone: "Europe/Paris",
   url: "http://hooli.com",
   zipcode: "91364",
-  billingConfiguration: {
-    invoiceGracePeriod: 3,
+  billing_configuration: {
+    invoice_grace_period: 3,
     paymentProvider:
       "stripe" as BillingConfigurationCustomer["paymentProvider"],
-    providerCustomerId: "cus_12345",
+    provider_customer_id: "cus_12345",
     sync: true,
-    syncWithProvider: true,
-    documentLocale: "fr"
+    sync_with_provider: true,
+    document_locale: "fr"
   },
   metadata: [
     {
       key: "Purchase Order",
       value: "123456789",
-      displayInInvoice: true,
+      display_in_invoice: true,
     },
   ],
 };

--- a/api-reference/customers/get-all.mdx
+++ b/api-reference/customers/get-all.mdx
@@ -34,7 +34,7 @@ client.customers.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.customers.findAllCustomers({ perPage: 2, page: 3 });
+await client.customers.findAllCustomers({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -79,8 +79,8 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new CustomersApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {
@@ -124,4 +124,5 @@ try {
   echo 'Exception when calling CustomersApi->findAllCustomers: ', $e->getMessage(), PHP_EOL;
 }
 ```
+
 </RequestExample>

--- a/api-reference/events/batch.mdx
+++ b/api-reference/events/batch.mdx
@@ -72,8 +72,8 @@ client.events.batch_create(
 
 ```js Javascript
 const batchEvent = {
-  transactionId: "__UNIQUE_TRANSACTION_ID__",
-  externalSubscriptionIds: ["__SUBSCRIPTION_ID_1__", "__SUBSCRIPTION_ID_2__"],
+  transaction_id: "__UNIQUE_TRANSACTION_ID__",
+  external_subscription_ids: ["__SUBSCRIPTION_ID_1__", "__SUBSCRIPTION_ID_2__"],
   code: "__BILLABLE_METRIC_CODE__",
   timestamp: 1650893379,
   properties: { customField: "custom" },
@@ -143,4 +143,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/events/usage.mdx
+++ b/api-reference/events/usage.mdx
@@ -69,9 +69,9 @@ client.events.create(
 ```js Javascript
 await client.events.createEvent({
   event: {
-    transactionId: "__UNIQUE_TRANSACTION_ID__",
-    externalCustomerId: "__UNIQUE_CUSTOMER_ID__",
-    externalSubscriptionId: "__UNIQUE_SUBSCRIPTION_ID__",
+    transaction_id: "__UNIQUE_TRANSACTION_ID__",
+    external_customer_id: "__UNIQUE_CUSTOMER_ID__",
+    external_subscription_id: "__UNIQUE_SUBSCRIPTION_ID__",
     code: "__BILLABLE_METRIC_CODE__",
     timestamp: 1650893379,
     properties: { customField: "custom" },
@@ -167,4 +167,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/fees/list-fees.mdx
+++ b/api-reference/fees/list-fees.mdx
@@ -3,7 +3,6 @@ openapi: "GET /fees"
 authMethod: "bearer"
 ---
 
-
 <RequestExample>
 
 ```bash cURL
@@ -25,7 +24,7 @@ client.fees.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.fees.findAllFees({ perPage: 2, page: 3 });
+await client.fees.findAllFees({ per_page: 2, page: 3 });
 ```
 
 ```go Go

--- a/api-reference/fees/update-fee.mdx
+++ b/api-reference/fees/update-fee.mdx
@@ -37,7 +37,7 @@ client.fees.update({
 
 ```js Javascript
 const feeObject = {
-  paymentStatus: "succeeded" as FeeObject["paymentStatus"],
+  payment_status: "succeeded" as FeeObject["payment_status"],
 };
 
 await client.fees.updateFee("1a901a90-1a90-1a90-1a90-1a901a901a90", {
@@ -92,4 +92,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/invoices/create-oneoff.mdx
+++ b/api-reference/invoices/create-oneoff.mdx
@@ -76,14 +76,14 @@ client.invoices.create({
 
 ```js Javascript
 const invoiceObject = {
-  externalCustomerId: "hooli_1234",
+  external_customer_id: "hooli_1234",
   currency: "USD",
   fees: [
     {
-      addOnCode: "setup_fee",
+      add_on_code: "setup_fee",
       description: "This is a description.",
       units: 2.5,
-      unitAmountCents: 1200
+      unit_amount_cents: 1200,
     },
   ],
 };
@@ -189,4 +189,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/invoices/get-all.mdx
+++ b/api-reference/invoices/get-all.mdx
@@ -34,7 +34,7 @@ client.invoices.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.invoices.findAllInvoices({ perPage: 2, page: 3 });
+await client.invoices.findAllInvoices({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -81,12 +81,12 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new InvoicesApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
-          var externalCustomerId = "12345";  // string | External customer ID (optional) 
-          var issuingDateFrom = 2022-07-08;  // string | Date from (optional) 
-          var issuingDateTo = 2022-08-09;  // string | Date to (optional) 
-          var status = draft;  // string | Status (draft or finalized) (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
+          var externalCustomerId = "12345";  // string | External customer ID (optional)
+          var issuingDateFrom = 2022-07-08;  // string | Date from (optional)
+          var issuingDateTo = 2022-08-09;  // string | Date to (optional)
+          var status = draft;  // string | Status (draft or finalized) (optional)
 
           try
           {

--- a/api-reference/invoices/update.mdx
+++ b/api-reference/invoices/update.mdx
@@ -79,7 +79,7 @@ client.invoices.update({
 
 ```js Javascript
 const invoiceObject = {
-  paymentStatus: "succeeded" as InvoiceObject["paymentStatus"],
+  payment_status: "succeeded" as InvoiceObject["payment_status"],
   metadata: [
     {
       key: "key",
@@ -189,4 +189,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/organizations/update.mdx
+++ b/api-reference/organizations/update.mdx
@@ -95,15 +95,15 @@ client.organizations.update(update_params)
 await client.organizations.updateOrganization({
   organization: {
     timezone: "America/New_York",
-    webhookUrl: "https://webhook.brex.com",
-    emailSettings: ["invoice.finalized"],
-    taxIdentificationNumber: "US123456789",
-    defaultCurrency: "USD",
-    billingConfiguration: {
-      invoiceFooter: "This is my customer footer",
-      invoiceGracePeriod: 3,
-      documentLocale: "en",
-      vatRate: 12.5,
+    webhook_url: "https://webhook.brex.com",
+    email_settings: ["invoice.finalized"],
+    tax_identification_number: "US123456789",
+    default_currency: "USD",
+    billing_configuration: {
+      invoice_footer: "This is my customer footer",
+      invoice_grace_period: 3,
+      document_locale: "en",
+      vat_rate: 12.5,
     },
   },
 });

--- a/api-reference/plans/create.mdx
+++ b/api-reference/plans/create.mdx
@@ -217,7 +217,7 @@ curl --location --request POST "$LAGO_URL/api/v1/plans" \
               "free_units_per_events": 5,
               "free_units_per_total_aggregation": "500",
               "per_transaction_min_amount": "1.75",
-              "per_transaction_max_amount": "2"              
+              "per_transaction_max_amount": "2"
             }
           }
         ],
@@ -598,19 +598,19 @@ client.plans.create(plan)
 import { ChargeObject, PlanInput } from "lago-javascript-client";
 
 const standardChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "standard" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "standard" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: true,
-  invoiceDisplayName: "New invoice display name",
-  taxCodes: ["french_standard_vat"],
-  groupProperties: [
+  invoice_display_name: "New invoice display name",
+  tax_codes: ["french_standard_vat"],
+  group_properties: [
     {
-      groupId: "group_id",
+      group_id: "group_id",
       values: {
         amount: "0.10",
       },
@@ -619,119 +619,119 @@ const standardChargeObject = {
 };
 
 const graduatedChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "graduated" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "graduated" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: false,
-  invoiceDisplayName: "",
+  invoice_display_name: "",
   properties: [
     {
-      toValue: 10,
-      fromValue: 0,
-      flatAmount: "0",
-      perUnitAmount: "0.00010",
+      to_value: 10,
+      from_value: 0,
+      flat_amount: "0",
+      per_unit_amount: "0.00010",
     },
     {
-      toValue: null,
-      fromValue: 11,
-      flatAmount: "0",
-      perUnitAmount: "0.0005",
+      to_value: null,
+      from_value: 11,
+      flat_amount: "0",
+      per_unit_amount: "0.0005",
     },
   ],
 };
 
 const packageChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "package" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "package" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: false,
-  invoiceDisplayName: "",
+  invoice_display_name: "",
   properties: {
     amount: "100",
-    freeUnits: 10000,
-    packageSize: 1000,
+    free_units: 10000,
+    package_size: 1000,
   },
 };
 
 const percentageChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "percentage" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "percentage" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: false,
-  invoiceDisplayName: "",
+  invoice_display_name: "",
   properties: {
     rate: "0.5",
-    fixedAmount: "1",
-    freeUnitsPerEvents: 3,
-    freeUnitsPerTotalAggregation: null,
-    perTransactionMinAmount: "1.75",
-    perTransactionMaxAmount: "2"
+    fixed_amount: "1",
+    free_units_per_events: 3,
+    free_units_per_total_aggregation: null,
+    per_transaction_min_amount: "1.75",
+    per_transaction_max_amount: "2"
   },
 };
 
 const volumeChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "volume" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "volume" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: true,
-  invoiceDisplayName: "",
+  invoice_display_name: "",
   properties: {
-    volumeRanges: [
+    volume_ranges: [
       {
-        toValue: 10,
-        fromValue: 0,
-        flatAmount: "0",
-        perUnitAmount: "0.00010",
+        to_value: 10,
+        from_value: 0,
+        flat_amount: "0",
+        per_unit_amount: "0.00010",
       },
       {
-        toValue: null,
-        fromValue: 11,
-        flatAmount: "0",
-        perUnitAmount: "0.0005",
+        to_value: null,
+        from_value: 11,
+        flat_amount: "0",
+        per_unit_amount: "0.0005",
       },
     ],
   },
 };
 
 const graduatePercentageChargeObject = {
-  lagoId: null,
-  billableMetricCode: null,
-  createdAt: null,
-  lagoBillableMetricId: "id",
-  chargeModel: "graduated_percentage" as ChargeObject["chargeModel"],
-  payInAdvance: false,
-  minAmountCents: 0,
+  lago_id: null,
+  billable_metric_code: null,
+  created_at: null,
+  lago_billable_metric_id: "id",
+  charge_model: "graduated_percentage" as ChargeObject["chargeModel"],
+  pay_in_advance: false,
+  min_amount_cents: 0,
   prorated: true,
-  invoiceDisplayName: "",
+  invoice_display_name: "",
   properties: {
-    volumeRanges: [
+    volume_ranges: [
       {
-        fromValue: 0,
-        toValue: 10,
+        from_value: 0,
+        to_value: 10,
         rate: "1",
-        flatAmount: "100"
+        flat_amount: "100"
       },
       {
-        fromValue: 11,
-        toValue: null,
+        from_value: 11,
+        to_value: null,
         rate: "2",
-        flatAmount: "0"
+        flat_amount: "0"
       },
     ],
   },
@@ -746,19 +746,19 @@ const charges = [
   graduatePercentageChargeObject
 ];
 
-const planObject: PlanInput = {
+const plan_object: PlanInput = {
   plan: {
     name: "Startup",
     code: "startup",
     interval: "monthly",
-    amountCents: 10000,
-    amountCurrency: "USD",
-    payInAdvance: true,
-    trialPeriod: 2,
+    amount_cents: 10000,
+    amount_currency: "USD",
+    pay_in_advance: true,
+    trial_period: 2,
     description: "This is a startup plan.",
-    invoiceDisplayName: "",
-    billChargesMonthly: false,
-    taxCodes: ["french_standard_vat"],
+    invoice_display_name: "",
+    bill_charges_monthly: false,
+    tax_codes: ["french_standard_vat"],
     charges: charges,
   },
 };

--- a/api-reference/plans/get-all-plans.mdx
+++ b/api-reference/plans/get-all-plans.mdx
@@ -34,7 +34,7 @@ client.plans.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.plans.findAllPlans({ perPage: 2, page: 3 });
+await client.plans.findAllPlans({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -79,8 +79,8 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new PlansApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {

--- a/api-reference/plans/update.mdx
+++ b/api-reference/plans/update.mdx
@@ -85,7 +85,7 @@ curl --location --request PUT "$LAGO_URL/api/v1/plans/__plan_code__" \
           "free_units_per_events": 5,
           "free_units_per_total_aggregation": "500",
           "per_transaction_min_amount": "1.75",
-          "per_transaction_max_amount": "2"     
+          "per_transaction_max_amount": "2"
         },
         "tax_codes": []
       },
@@ -216,7 +216,7 @@ curl --location --request PUT "$LAGO_URL/api/v1/plans/__plan_code__" \
             "free_units_per_events": 5,
             "free_units_per_total_aggregation": "500",
             "per_transaction_min_amount": "1.75",
-            "per_transaction_max_amount": "2"     
+            "per_transaction_max_amount": "2"
             }
           }
         ],
@@ -581,7 +581,7 @@ client.plans.update(plan, "__identifier__")
 ```
 
 ```js Javascript
-await client.plans.updatePlan("code", { plan: { amountCents: 2000 } });
+await client.plans.updatePlan("code", { plan: { amount_cents: 2000 } });
 ```
 
 ```go Go

--- a/api-reference/subscriptions/assign-plan.mdx
+++ b/api-reference/subscriptions/assign-plan.mdx
@@ -91,7 +91,7 @@ curl --location --request POST "$LAGO_URL/api/v1/subscriptions" \
             "free_units_per_total_aggregation": "500",
             "per_transaction_max_amount": "3.75",
             "per_transaction_min_amount": "1.75"
-          } 
+          }
         },
         {
           "id": "cha_171819",
@@ -107,7 +107,7 @@ curl --location --request POST "$LAGO_URL/api/v1/subscriptions" \
                 "per_unit_amount": "0.5"
               }
             ]
-          } 
+          }
         },
         {
           "id": "cha_202122",
@@ -179,13 +179,13 @@ client.subscriptions.create(
 import { Client, SubscriptionObject } from "lago-javascript-client";
 
 const subscriptionObject = {
-  externalCustomerId: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
-  planCode: "statup_plan",
-  externalId: "sub_id_123456789",
+  external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d8885990ba",
+  plan_code: "statup_plan",
+  external_id: "sub_id_123456789",
   name: "Repository A",
-  subscriptionAt: "2022-08-08T00:00:00Z",
-  endingAt: "2023-08-08T00:00:00Z",
-  billingTime: "anniversary" as SubscriptionObject["billingTime"],
+  subscription_at: "2022-08-08T00:00:00Z",
+  ending_at: "2023-08-08T00:00:00Z",
+  billing_time: "anniversary" as SubscriptionObject["billingTime"],
 };
 
 await client.subscriptions.createSubscription({

--- a/api-reference/subscriptions/get-all.mdx
+++ b/api-reference/subscriptions/get-all.mdx
@@ -36,8 +36,8 @@ client.subscriptions.get_all({ external_customer_id: '123'})
 
 ```js Javascript
 await client.subscriptions.findAllSubscriptions({
-  externalCustomerId: "123",
-  page: 1
+  external_customer_id: "123",
+  page: 1,
 });
 ```
 
@@ -108,4 +108,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/subscriptions/get-specific.mdx
+++ b/api-reference/subscriptions/get-specific.mdx
@@ -35,7 +35,7 @@ client.subscriptions.get('external_id')
 ```
 
 ```js Javascript
-await client.subscriptions.findSubscription('externalId')
+await client.subscriptions.findSubscription("external_id");
 ```
 
 ```go Go

--- a/api-reference/subscriptions/update.mdx
+++ b/api-reference/subscriptions/update.mdx
@@ -87,7 +87,7 @@ curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/:id" \
             "free_units_per_total_aggregation": "500",
             "per_transaction_max_amount": "3.75",
             "per_transaction_min_amount": "1.75"
-          } 
+          }
         },
         {
           "id": "cha_171819",
@@ -103,7 +103,7 @@ curl --location --request PUT "$LAGO_URL/api/v1/subscriptions/:id" \
                 "per_unit_amount": "0.5"
               }
             ]
-          } 
+          }
         },
         {
           "id": "cha_202122",
@@ -158,7 +158,11 @@ client.subscriptions.update(update_params, 'id')
 
 ```js Javascript
 await client.subscriptions.updateSubscription("external_id", {
-  subscription: { name: "new name", subscriptionAt: "2022-08-08T00:00:00Z", endingAt: "2023-08-08T00:00:00Z" },
+  subscription: {
+    name: "new name",
+    subscription_at: "2022-08-08T00:00:00Z",
+    ending_at: "2023-08-08T00:00:00Z",
+  },
 });
 ```
 
@@ -227,4 +231,3 @@ try {
 ```
 
 </RequestExample>
-

--- a/api-reference/taxes/create.mdx
+++ b/api-reference/taxes/create.mdx
@@ -66,7 +66,7 @@ const taxObject = {
   code: "french_standard_vat",
   rate: "20.0",
   description: "French standard VAT",
-  appliedToOrganization: false
+  applied_to_organization: false,
 };
 
 await client.taxes.createTax({ tax: taxObject });
@@ -131,7 +131,7 @@ namespace Example
             }
             catch (ApiException e)
             {
-							 
+
             }
         }
     }

--- a/api-reference/taxes/get-all.mdx
+++ b/api-reference/taxes/get-all.mdx
@@ -22,7 +22,7 @@ client = Client(api_key='__YOUR_API_KEY__')
 try:
     client.taxes.find_all({'per_page': 2, 'page': 1})
 except LagoApiError as e:
-    repair_broken_state(e) 
+    repair_broken_state(e)
 ```
 
 ```ruby Ruby
@@ -34,7 +34,7 @@ client.taxes.get_all({ per_page: 2, page: 3 })
 ```
 
 ```js Javascript
-await client.taxes.findAllTaxes({ perPage: 2, page: 3 });
+await client.taxes.findAllTaxes({ per_page: 2, page: 3 });
 ```
 
 ```go Go
@@ -75,8 +75,8 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new TaxesApi(Configuration.Default);
-          var page = 2; 
-          var perPage = 20; 
+          var page = 2;
+          var perPage = 20;
 
           try
           {

--- a/api-reference/taxes/update.mdx
+++ b/api-reference/taxes/update.mdx
@@ -66,10 +66,10 @@ const taxObject = {
   code: "french_standard_vat",
   rate: "20.0",
   description: "French standard VAT",
-  appliedToOrganization: false
+  applied_to_organization: false,
 };
 
-await client.taxes.updateTax('french_standard_vat', { tax: taxObject });
+await client.taxes.updateTax("french_standard_vat", { tax: taxObject });
 ```
 
 ```go Go
@@ -131,7 +131,7 @@ namespace Example
             }
             catch (ApiException e)
             {
-							 
+
             }
         }
     }

--- a/api-reference/wallets/create.mdx
+++ b/api-reference/wallets/create.mdx
@@ -68,12 +68,12 @@ client.wallets.create({
 await client.wallets.createWallet({
   wallet: {
     name: "Prepaid",
-    currency: 'USD',
-    rateAmount: 1.5,
-    paidCredits: 20.0,
-    grantedCredits: 10.0,
-    expirationAt: "2022-07-07T23:59:59Z",
-    externalCustomerId: "hooli_1234",
+    currency: "USD",
+    rate_amount: 1.5,
+    paid_credits: 20.0,
+    granted_credits: 10.0,
+    expiration_at: "2022-07-07T23:59:59Z",
+    external_customer_id: "hooli_1234",
   },
 });
 ```

--- a/api-reference/wallets/get-all-transactions.mdx
+++ b/api-reference/wallets/get-all-transactions.mdx
@@ -35,7 +35,7 @@ client.wallet_transactions.get_all({ per_page: 2, page: 3 })
 
 ```js Javascript
 await client.wallets.findAllWalletTransactions("wallet-id", {
-  perPage: 2,
+  per_page: 2,
   page: 3,
 });
 ```
@@ -84,8 +84,8 @@ namespace Example
 
           var apiInstance = new WalletsApi(Configuration.Default);
           var externalCustomerId = "12345";  // string | External customer ID
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {
@@ -103,4 +103,5 @@ namespace Example
   }
 }
 ```
+
 </RequestExample>

--- a/api-reference/wallets/get-all.mdx
+++ b/api-reference/wallets/get-all.mdx
@@ -35,8 +35,8 @@ client.wallets.get_all({ external_customer_id: hooli_1234, per_page: 2, page: 3 
 
 ```js Javascript
 await client.wallets.findAllWallets({
-  externalCustomerId: 'hooli_1234',
-  perPage: 2,
+  external_customer_id: "hooli_1234",
+  per_page: 2,
   page: 3,
 });
 ```
@@ -85,8 +85,8 @@ namespace Example
 
           var apiInstance = new WalletsApi(Configuration.Default);
           var externalCustomerId = "hooli_1234";  // string | External customer ID
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {

--- a/api-reference/wallets/top-up.mdx
+++ b/api-reference/wallets/top-up.mdx
@@ -54,10 +54,10 @@ client.wallet_transactions.create({
 
 ```js Javascript
 await client.walletTransactions.createWalletTransaction({
-  walletTransaction: {
-    walletId: "wallet_1234",
-    paidCredits: 20.0,
-    grantedCredits: 10.0,
+  wallet_transaction: {
+    wallet_id: "wallet_1234",
+    paid_credits: 20.0,
+    granted_credits: 10.0,
   },
 });
 ```

--- a/api-reference/wallets/update.mdx
+++ b/api-reference/wallets/update.mdx
@@ -51,7 +51,7 @@ client.wallets.update({
 
 ```js Javascript
 await client.wallets.updateWallet("wallet-id", {
-  wallet: { name: "Prepaid Credits", expirationAt: "2022-07-07T23:59:59Z" },
+  wallet: { name: "Prepaid Credits", expiration_at: "2022-07-07T23:59:59Z" },
 });
 ```
 

--- a/api-reference/webhook-endpoints/create.mdx
+++ b/api-reference/webhook-endpoints/create.mdx
@@ -52,9 +52,9 @@ client.webhook_endpoints.create({
 
 ```js Javascript
 await client.webhookEndpoints.createWebhookEndpoint({
-  webhookEndpoint: {
-    webhookUrl: "https://foo.bar",
-    signatureAlgo: 'hmac'
+  webhook_endpoint: {
+    webhook_url: "https://foo.bar",
+    signature_algo: "hmac",
   },
 });
 ```

--- a/api-reference/webhook-endpoints/get-all.mdx
+++ b/api-reference/webhook-endpoints/get-all.mdx
@@ -36,7 +36,7 @@ client.webhook_endpoints.get_all({ per_page: 2, page: 3 })
 
 ```js Javascript
 await client.webhookEndpoints.findAllWebhookEndpoints({
-  perPage: 2,
+  per_page: 2,
   page: 3,
 });
 ```
@@ -83,8 +83,8 @@ namespace Example
           Configuration.Default.AccessToken = "YOUR_ACCESS_TOKEN";
 
           var apiInstance = new WebhookEndpointsApi(Configuration.Default);
-          var page = 2;  // int? | Number of page (optional) 
-          var perPage = 20;  // int? | Number of records per page (optional) 
+          var page = 2;  // int? | Number of page (optional)
+          var perPage = 20;  // int? | Number of records per page (optional)
 
           try
           {

--- a/api-reference/webhook-endpoints/update.mdx
+++ b/api-reference/webhook-endpoints/update.mdx
@@ -52,7 +52,7 @@ client.webhook_endpoints.update({
 
 ```js Javascript
 await client.webhook_endpoints.updateWebhookEndpoint("webhook-endpoint-id", {
-  webhookEndpoint: { webhookUrl: "https://foo.bar" },
+  webhook_endpoint: { webhook_url: "https://foo.bar" },
 });
 ```
 


### PR DESCRIPTION
The JS client uses `camel_case` notation for it's attribute but documentation uses `pascalCase`.

This PR turns them all into `camel_case`

Also, some extra spacing changes are presents