### PR TITLE
doc(Analytics): Edit gross revenue guide

### DIFF
--- a/guide/analytics/gross-revenue.mdx
+++ b/guide/analytics/gross-revenue.mdx
@@ -10,8 +10,9 @@ In essence, it's the amount you should expect to receive every month.
 
 1. All `finalized` invoices, whether related to subscriptions or usage;
 2. Pay in advance fees, whether they are invoiceable or not;
-3. Invoices related to prepaid credits from wallets; and
-4. One-off invoices.
+3. Invoices related to prepaid credits from wallets;
+4. One-off invoices; and
+5. Deducting the credit note amounts `refunded` to customers.
 
 <Tabs>
   <Tab title="Dashboard"> 
@@ -48,7 +49,7 @@ In essence, it's the amount you should expect to receive every month.
                 SELECT
                     DATE_TRUNC('month', o.created_at) AS start_month
                 FROM organizations o
-                WHERE o.id = '__YOUR_ORGANIZATION_ID__'
+                WHERE o.id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
             ),
 
             --- Generate a number of date series in the future
@@ -56,7 +57,7 @@ In essence, it's the amount you should expect to receive every month.
                 SELECT
                     generate_series(
                         (SELECT start_month FROM organization_creation_date),
-                        DATE_TRUNC('month', CURRENT_DATE + INTERVAL '10 years'),
+                        DATE_TRUNC('month', CURRENT_DATE + INTERVAL '10 years'), 
                         interval '1 month'
                     ) AS month
             ),
@@ -64,29 +65,36 @@ In essence, it's the amount you should expect to receive every month.
             --- Get value for all issued invoices
             issued_invoices AS (
                 SELECT
+                    i.id,
                     i.issuing_date,
                     i.total_amount_cents::float AS amount_cents,
-                    i.currency
+                    i.currency,
+                    COALESCE(SUM(refund_amount_cents::float),0) AS total_refund_amount_cents
                 FROM invoices i
                 LEFT JOIN customers c ON i.customer_id = c.id
-                WHERE i.organization_id = '__YOUR_ORGANIZATION_ID__'
+                LEFT JOIN credit_notes cn ON cn.invoice_id = i.id
+                WHERE i.organization_id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
                     AND i.status = 1
-                    ---AND c.external_id = '' --- Filter by customer if needed
+                    ---AND c.external_id = 'hooli_1234' --- FILTER BY CUSTOMER
+                GROUP BY i.id, i.issuing_date, i.total_amount_cents, i.currency
+                ORDER BY i.issuing_date ASC
             ),
 
             --- Get value for all instant charges (paid in advance but not invoiceable)
             instant_charges AS (
                 SELECT
+                    f.id,
                     f.created_at AS issuing_date,
                     f.amount_cents AS amount_cents,
-                    f.amount_currency AS currency
+                    f.amount_currency AS currency,
+                    0 AS total_refund_amount_cents
                 FROM fees f
                 LEFT JOIN subscriptions s ON f.subscription_id = s.id
                 LEFT JOIN customers c ON c.id = s.customer_id
-                WHERE c.organization_id = '__YOUR_ORGANIZATION_ID__'
+                WHERE c.organization_id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
                     AND f.invoice_id IS NULL
                     AND f.pay_in_advance IS TRUE
-                    ---AND c.external_id = '' --- FILTER BY CUSTOMER
+                    ---AND c.external_id = 'hooli_1234' --- FILTER BY CUSTOMER
             ),
 
             --- Combine data to get total of gross revenue
@@ -94,26 +102,29 @@ In essence, it's the amount you should expect to receive every month.
                 SELECT
                     DATE_TRUNC('month', issuing_date) AS month,
                     currency,
-                    COALESCE(SUM(amount_cents), 0) AS amount_cents
+                    COALESCE(SUM(amount_cents), 0) AS amount_cents,
+                    COALESCE(SUM(total_refund_amount_cents), 0) AS total_refund_amount_cents
                 FROM (
                     SELECT * FROM issued_invoices
                     UNION ALL
                     SELECT * FROM instant_charges
                 ) AS gross_revenue
-                GROUP BY month, currency
+                GROUP BY month, currency, total_refund_amount_cents
             )
 
             --- Get gross revenue month over month
             SELECT
                 am.month,
-                cd.amount_cents,
-                cd.currency
+                cd.currency,
+                SUM(cd.amount_cents - cd.total_refund_amount_cents) AS amount_cents
             FROM all_months am
             LEFT JOIN combined_data cd ON am.month = cd.month
             WHERE am.month <= DATE_TRUNC('month', CURRENT_DATE)
+                ---AND am.month >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL '11 months') --- LAST 12 MONTHS
                 AND cd.amount_cents IS NOT NULL
-                --- AND cd.currency = 'EUR' --- Filter by currency if needed
-            ORDER BY am.month;
+                --- AND cd.currency = 'EUR'
+            GROUP BY am.month, cd.currency
+            ORDER BY am.month
         ```
         </CodeGroup>
 

--- a/guide/analytics/gross-revenue.mdx
+++ b/guide/analytics/gross-revenue.mdx
@@ -49,7 +49,7 @@ In essence, it's the amount you should expect to receive every month.
                 SELECT
                     DATE_TRUNC('month', o.created_at) AS start_month
                 FROM organizations o
-                WHERE o.id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
+                WHERE o.id = '__YOUR_ORGANIZATION_ID__'
             ),
 
             --- Generate a number of date series in the future
@@ -73,7 +73,7 @@ In essence, it's the amount you should expect to receive every month.
                 FROM invoices i
                 LEFT JOIN customers c ON i.customer_id = c.id
                 LEFT JOIN credit_notes cn ON cn.invoice_id = i.id
-                WHERE i.organization_id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
+                WHERE i.organization_id = '__YOUR_ORGANIZATION_ID__'
                     AND i.status = 1
                     ---AND c.external_id = 'hooli_1234' --- FILTER BY CUSTOMER
                 GROUP BY i.id, i.issuing_date, i.total_amount_cents, i.currency
@@ -91,7 +91,7 @@ In essence, it's the amount you should expect to receive every month.
                 FROM fees f
                 LEFT JOIN subscriptions s ON f.subscription_id = s.id
                 LEFT JOIN customers c ON c.id = s.customer_id
-                WHERE c.organization_id = '03d8c1d4-ba10-4cf6-993a-39c698664f38'
+                WHERE c.organization_id = '__YOUR_ORGANIZATION_ID__'
                     AND f.invoice_id IS NULL
                     AND f.pay_in_advance IS TRUE
                     ---AND c.external_id = 'hooli_1234' --- FILTER BY CUSTOMER


### PR DESCRIPTION
## Description

Specify that Gross revenue is calculated from :

1. All `finalized` invoices, whether related to subscriptions or usage;
2. Pay in advance fees, whether they are invoiceable or not;
3. Invoices related to prepaid credits from wallets;
4. One-off invoices; and
5. **Deducting the credit note amounts `refunded` to customers.**