### PR TITLE
Add correct link to Github Commit Activity

### DIFF
--- a/faq/about-lago.mdx
+++ b/faq/about-lago.mdx
@@ -168,4 +168,4 @@ Yes. Lago is agnostic and can be used via:
 
 ## 5. Is this supported properly?
 
-Lago is a well funded project with thousands of stars on [Github](https://github.com/getlago/lago), in [very active development](https://github.com/PostHog/posthog/graphs/commit-activity), by our [core team](https://www.getlago.com/about-us) and our active community.
+Lago is a well funded project with thousands of stars on [Github](https://github.com/getlago/lago), in [very active development](https://github.com/getlago/lago-api/graphs/commit-activity), by our [core team](https://www.getlago.com/about-us) and our active community.


### PR DESCRIPTION
previous link was pointing to PostHog, another open-source SaaS product.