### PR TITLE
Update outdated python client for Batch usage events

### DIFF
--- a/api-reference/events/batch.mdx
+++ b/api-reference/events/batch.mdx
@@ -37,8 +37,8 @@ from lago_python_client.models import BatchEvent
 client = Client(api_key='__YOUR_API_KEY__')
 
 # Create a list of events
-events = [
-    BatchEvent(
+batch_event = BatchEvent(events=[
+    Event(
         transaction_id="__UNIQUE_ID_1__",
         external_customer_id="__CUSTOMER_ID_1__",
         external_subscription_id="__SUBSCRIPTION_ID_1__",
@@ -46,7 +46,7 @@ events = [
         timestamp=1650893379,
         properties={"custom_field": "custom"}
     ),
-    BatchEvent(
+    Event(
         transaction_id="__UNIQUE_ID_2__",
         external_subscription_id="__SUBSCRIPTION_ID_2__",
         external_customer_id="__CUSTOMER_ID_2__",
@@ -55,9 +55,9 @@ events = [
         properties={"custom_field": "custom"}
     )
     # Add more events as needed
-]
+])
 try:
-    client.events.batch_create(events)
+    client.events.batch_create(batch_event)
 except LagoApiError as e:
     repair_broken_state(e)  # do something on error or raise your own exception
 ```


### PR DESCRIPTION
Documentation in this [page](https://docs.getlago.com/api-reference/events/batch) is outdated after this endpoint change https://github.com/getlago/lago-python-client/pull/219