### PR TITLE
doc(Subscription): Fix typo $ to \$

### DIFF
--- a/guide/subscriptions/assign-plan.mdx
+++ b/guide/subscriptions/assign-plan.mdx
@@ -62,8 +62,8 @@ Optimize billing for your customers by assigning subscriptions based on either c
 
     Consider the following example:
 
-    >Your customer signs up for the Premium plan, $50 monthly, on August 10th. There are 22 days left until the end of the month, including August 10th. Therefore, the subscription fee for August is:
-    >**22 days x $50 / 31 days = $35.48**
+    >Your customer signs up for the Premium plan, \$50 monthly, on August 10th. There are 22 days left until the end of the month, including August 10th. Therefore, the subscription fee for August is:
+    >**22 days x \$50 / 31 days = \$35.48**
 
   <Frame caption="Calendar billing cadence">
     <img src="/guide/subscriptions/images/calendar-date-227bf60245e9d3715d3383098c88c1b0.png" />


### PR DESCRIPTION
### Description

Add `\` next to $ sign to avoid markdown style