### PR TITLE
Add additional details for automatic adyen customer creation 

### DIFF
--- a/integrations/payments/adyen-integration.mdx
+++ b/integrations/payments/adyen-integration.mdx
@@ -108,6 +108,10 @@ Upon successful customer creation, you will receive two **[webhook messages](/ap
 2. **`customer.payment_provider_created`**: This message confirms the successful creation of the customer in Adyen, indicating that the customer's details have been added to the Adyen database.
 
 <Warning>
+You may need to enable Developers -> Additional Data -> Payment -> Recurring details for the customer to be automatically created. 
+</Warning>
+
+<Warning>
 Please note that the customer will be created in Adyen only if the payment method has been stored through the checkout URL and pre-authorization payment.
 </Warning>
 


### PR DESCRIPTION
I had issues getting customers to be created automatically following the documentation. For some reason I had to enable _Recurring details_ within _Additional data_ to get it to work. I didn't seem to be receiving a `shopperReference` without it. This was on a newly created test account made a few days ago. I figured this out based on this [code](https://github.com/getlago/lago-api/blob/d42f2e48cbad9b87e45f116fd8df3e42214e4dd0/app/services/payment_provider_customers/adyen_service.rb#L101-L104).

Free feel to edit my copy - this was mostly for other persons who face the same issue. Thanks!  

![image](https://github.com/getlago/lago-doc/assets/5731551/27f01edb-f550-4bc8-8587-027d3fdd4f55)
