### PR TITLE
doc(Subscription): Correct typo on terminate sub

### DIFF
--- a/api-reference/subscriptions/terminate.mdx
+++ b/api-reference/subscriptions/terminate.mdx
@@ -46,7 +46,7 @@ func main() {
 lagoClient := lago.New().
     SetApiKey("__YOUR_API_KEY__")
 
-subscription, err := lagoClient.Subscription().Terminate("__YOUR_CUSTOMER_ID__")
+subscription, err := lagoClient.Subscription().Terminate("__EXTERNAL_ID__")
 if err != nil {
     // Error is *lago.Error
     panic(err)
@@ -120,4 +120,3 @@ try {
 ```
 
 </RequestExample>
-


### PR DESCRIPTION
### Terminate subscription

Update from `customer_id` to `subscription.external_id` for go client