### PR TITLE
feat(wallet): Rename transaction statuses for wallet

### DIFF
--- a/api-reference/webhooks/messages.mdx
+++ b/api-reference/webhooks/messages.mdx
@@ -976,6 +976,10 @@ description: "Here is the complete list of webhook messages sent by Lago."
       Returning a subscription object.
     </ResponseField>
   </Accordion>
+</AccordionGroup>
+
+## Wallets
+<AccordionGroup>
   <Accordion title="Wallet transaction created">
     Sent when a wallet transaction is created.
 
@@ -987,7 +991,7 @@ description: "Here is the complete list of webhook messages sent by Lago."
         "lago_id": "773e24d0-28f3-4af5-b5c4-207557b0beeb",
         "lago_wallet_id": "103f64c4-933b-467f-8786-dd3c0f6fab97",
         "status": "pending",
-        "transaction_status": "paid",
+        "transaction_status": "purchased",
         "transaction_type": "inbound",
         "amount": "100.0",
         "credit_amount": "100.0",

--- a/lago-openapi.yaml
+++ b/lago-openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Lago API documentation
   description: Lago API allows your application to push customer information and metrics (events) from your application to the billing application.
-  version: 1.1.0
+  version: 1.2.0
   license:
     name: AGPLv3
   contact:
@@ -2395,12 +2395,12 @@ paths:
             example: pending
         - name: transaction_status
           in: query
-          description: "The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type)."
+          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).'
           required: false
           explode: true
           schema:
             type: string
-            example: paid
+            example: purchased
         - name: transaction_type
           in: query
           description: The transaction type of the wallet transaction. Possible values are `inbound` (increasing the wallet balance) or `outbound` (decreasing the wallet balance).
@@ -8539,11 +8539,11 @@ components:
         transaction_status:
           type: string
           enum:
-            - paid
-            - offered
+            - purchased
+            - granted
             - voided
-          description: "The transaction status of the wallet transaction. Possible values are `paid` (with pending or settled status), `offered` (settled status but null invoice_id) or `voided` (with outbound transaction type)."
-          example: paid
+          description: 'The transaction status of the wallet transaction. Possible values are `purchased` (with pending or settled status), `granted` (without invoice_id) or `voided` (with outbound transaction type).'
+          example: purchased
         transaction_type:
           type: string
           enum:


### PR DESCRIPTION
## Context

We want to differentiate a free wallet transaction vs. a paid wallet transaction.
And be able to void some wallet transactions.

## Description

This PR aims to rename:

- `paid` to `purchased`
- `offered` to `granted`

for the `transaction_status` field for Wallet.
