### PR TITLE
Update go snippets to send events

### DIFF
--- a/api-reference/events/batch.mdx
+++ b/api-reference/events/batch.mdx
@@ -113,6 +113,31 @@ await client.events.createBatchEvents({ events: batchEvent });
 
 ```
 
+```go Go
+import "fmt"
+import "github.com/getlago/lago-go-client"
+
+func main() {
+  ctx := context.Background()
+  lagoClient := lago.New().SetApiKey("__YOUR_API_KEY__")
+
+  event := lago.EventInput{
+    TransactionID:          "__UNIQUE_TRANSACTION_ID__",
+    ExternalSubscriptionID: "__UNIQUE_SUBSCRIPTION_ID__",
+    Code:                   "__BILLABLE_METRIC_CODE__",
+    Timestamp:              strconv.FormatInt(time.Now().Unix(), 10),
+    Properties: map[string]interface{}{
+      "nbusers": "12",
+    },
+  }
+
+  batchInput := make([]lago.EventInput, 1)
+  batchInput[0] = event
+
+  res, err := lagoClient.Event().Batch(ctx, &batchInput)
+}
+```
+
 ```csharp C#
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/api-reference/events/usage.mdx
+++ b/api-reference/events/usage.mdx
@@ -80,24 +80,26 @@ import "fmt"
 import "github.com/getlago/lago-go-client"
 
 func main() {
-lagoClient := lago.New().
-    SetApiKey("__YOUR_API_KEY__")
+	ctx := context.Background()
+	lagoClient := lago.New().SetApiKey("__YOUR_API_KEY__")
 
-eventInput := &lago.EventInput{
-    TransactionID: "__UNIQUE_TRANSACTION_ID__",
-    ExternalSubscriptionID: "__UNIQUE_SUBSCRIPTION_ID__",
-    Code:          "__BILLABLE_METRIC_CODE__",
-    Timestamp:     time.Now().Unix(),
-    Properties: map[string]string{
-            "nbusers": "12",
-        },
-}
+	eventInput := &lago.EventInput{
+		TransactionID:          "__UNIQUE_TRANSACTION_ID__",
+		ExternalSubscriptionID: "__UNIQUE_SUBSCRIPTION_ID__",
+		Code:                   "__BILLABLE_METRIC_CODE__",
+		Timestamp:              strconv.FormatInt(time.Now().Unix(), 10),
+		Properties: map[string]interface{}{
+			"nbusers": "12",
+		},
+	}
 
-err := lagoClient.Event().Create(eventInput)
-if err != nil {
-    // Error is *lago.Error
-    panic(err)
-}
+	res, err := lagoClient.Event().Create(ctx, eventInput)
+	if err != nil {
+		// err is *lago.Error
+		panic(err)
+	}
+	// res is *lago.Event
+	fmt.Println(*res)
 }
 ```
 


### PR DESCRIPTION
* The snippet to send one event was outdated (missing context, using wrong Properties type, wrong return from Create).
* The batch didn't have a snippet.