### PR TITLE
Fix documentation for initializing Lago::Api::Client

### DIFF
--- a/api-reference/add-ons/create.mdx
+++ b/api-reference/add-ons/create.mdx
@@ -50,7 +50,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 add_on = {
   name: 'Setup Fee',

--- a/api-reference/add-ons/destroy.mdx
+++ b/api-reference/add-ons/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.add_ons.destroy('code')
 ```

--- a/api-reference/add-ons/get-all.mdx
+++ b/api-reference/add-ons/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.add_ons.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/add-ons/get-specific.mdx
+++ b/api-reference/add-ons/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.add_ons.get('code')
 ```

--- a/api-reference/add-ons/update.mdx
+++ b/api-reference/add-ons/update.mdx
@@ -42,7 +42,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 update_params = {name: 'Setup Fee'}
 client.add_ons.update(update_params, 'setup_fee')

--- a/api-reference/billable-metrics/create.mdx
+++ b/api-reference/billable-metrics/create.mdx
@@ -63,7 +63,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.billable_metrics.create({
   name: 'Storage',

--- a/api-reference/billable-metrics/destroy.mdx
+++ b/api-reference/billable-metrics/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.billable_metrics.destroy('code')
 ```

--- a/api-reference/billable-metrics/get-all-groups.mdx
+++ b/api-reference/billable-metrics/get-all-groups.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.groups.get_all('billable_metric_code', { per_page: 2, page: 3 })
 ```

--- a/api-reference/billable-metrics/get-all.mdx
+++ b/api-reference/billable-metrics/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.billable_metrics.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/billable-metrics/get-specific.mdx
+++ b/api-reference/billable-metrics/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.billable_metrics.get('code')
 ```

--- a/api-reference/billable-metrics/update.mdx
+++ b/api-reference/billable-metrics/update.mdx
@@ -64,7 +64,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.billable_metrics.update({
   name: 'Storage',

--- a/api-reference/coupons/apply.mdx
+++ b/api-reference/coupons/apply.mdx
@@ -50,7 +50,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.applied_coupons.create(
   external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",

--- a/api-reference/coupons/create.mdx
+++ b/api-reference/coupons/create.mdx
@@ -63,7 +63,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 coupon = {
   name: 'Startup Deal',

--- a/api-reference/coupons/destroy-applied-coupon.mdx
+++ b/api-reference/coupons/destroy-applied-coupon.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.applied_coupons.destroy('external_customer_id', 'applied_coupon_id')
 ```

--- a/api-reference/coupons/destroy.mdx
+++ b/api-reference/coupons/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.coupons.destroy('code')
 ```

--- a/api-reference/coupons/get-all-applied.mdx
+++ b/api-reference/coupons/get-all-applied.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.applied_coupons.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/coupons/get-all.mdx
+++ b/api-reference/coupons/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.coupons.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/coupons/get-specific.mdx
+++ b/api-reference/coupons/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.coupons.get('code')
 ```

--- a/api-reference/coupons/update.mdx
+++ b/api-reference/coupons/update.mdx
@@ -47,7 +47,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 update_params = {name: 'new name'}
 client.coupons.update(update_params, 'code_bm')

--- a/api-reference/credit-notes/create.mdx
+++ b/api-reference/credit-notes/create.mdx
@@ -66,7 +66,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 credit_note = {
   invoice_id: '__LAGO_INVOICE_ID__',

--- a/api-reference/credit-notes/download.mdx
+++ b/api-reference/credit-notes/download.mdx
@@ -32,7 +32,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.credit_notes.download('__CREDIT_NOTE_ID__')
 ```

--- a/api-reference/credit-notes/get-all.mdx
+++ b/api-reference/credit-notes/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.credit_notes.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/credit-notes/get-specific.mdx
+++ b/api-reference/credit-notes/get-specific.mdx
@@ -30,7 +30,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.credit_notes.get('__CREDIT_NOTE_ID__')
 ```

--- a/api-reference/credit-notes/update.mdx
+++ b/api-reference/credit-notes/update.mdx
@@ -37,7 +37,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.credit_note.update(
   { refund_status: 'refunded' },

--- a/api-reference/credit-notes/void.mdx
+++ b/api-reference/credit-notes/void.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.credit_note.void('__CREDIT_NOTE_ID__')
 ```

--- a/api-reference/customer-usage/get-current.mdx
+++ b/api-reference/customer-usage/get-current.mdx
@@ -34,7 +34,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 customer_usage = client.customer.current_usage(
   'external_customer_id', 'external_subscription_id'
 )

--- a/api-reference/customer-usage/get-past.mdx
+++ b/api-reference/customer-usage/get-past.mdx
@@ -34,7 +34,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 customer_usage = client.customer.past_usage(
   'external_customer_id', 'external_subscription_id'
 )

--- a/api-reference/customers/create.mdx
+++ b/api-reference/customers/create.mdx
@@ -107,7 +107,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.create(
   external_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",

--- a/api-reference/customers/customer-portal.mdx
+++ b/api-reference/customers/customer-portal.mdx
@@ -30,7 +30,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.portal_url('external_id')
 ```

--- a/api-reference/customers/delete.mdx
+++ b/api-reference/customers/delete.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.destroy('external_id')
 ```

--- a/api-reference/customers/get-all.mdx
+++ b/api-reference/customers/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/customers/get-specific.mdx
+++ b/api-reference/customers/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.get('external_id')
 ```

--- a/api-reference/customers/psp-checkout-url.mdx
+++ b/api-reference/customers/psp-checkout-url.mdx
@@ -30,7 +30,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.checkout_url('external_id')
 ```

--- a/api-reference/customers/update.mdx
+++ b/api-reference/customers/update.mdx
@@ -108,7 +108,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.customers.create(
   external_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",

--- a/api-reference/events/estimated-fee.mdx
+++ b/api-reference/events/estimated-fee.mdx
@@ -40,7 +40,7 @@ client.events.estimate_fees(event)
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.events.estimate_fees(
   external_subscription_id: "__YOUR_SUBSCRIPTION_ID__",

--- a/api-reference/events/get-specific.mdx
+++ b/api-reference/events/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.events.get('transaction_id')
 ```

--- a/api-reference/events/usage.mdx
+++ b/api-reference/events/usage.mdx
@@ -50,7 +50,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.events.create(
   transaction_id: "__UNIQUE_ID__",

--- a/api-reference/fees/retrieve-fee.mdx
+++ b/api-reference/fees/retrieve-fee.mdx
@@ -30,7 +30,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.fees.get('id')
 ```

--- a/api-reference/intro.mdx
+++ b/api-reference/intro.mdx
@@ -66,7 +66,7 @@ $ gem install lago-ruby-client
 ```ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 ```
 
 </Tab>

--- a/api-reference/invoices/create-oneoff.mdx
+++ b/api-reference/invoices/create-oneoff.mdx
@@ -59,7 +59,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.create({
   external_customer_id: "hooli_1234",

--- a/api-reference/invoices/download.mdx
+++ b/api-reference/invoices/download.mdx
@@ -32,7 +32,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.download('__YOUR_INVOICE_ID__') // Invoice ID
 ```

--- a/api-reference/invoices/finalize.mdx
+++ b/api-reference/invoices/finalize.mdx
@@ -31,7 +31,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.finalize('__INVOICE_ID__') // Invoice ID
 ```

--- a/api-reference/invoices/get-all.mdx
+++ b/api-reference/invoices/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/invoices/get-specific.mdx
+++ b/api-reference/invoices/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.get('lago_id')
 ```

--- a/api-reference/invoices/refresh.mdx
+++ b/api-reference/invoices/refresh.mdx
@@ -31,7 +31,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.refresh('__INVOICE_ID__') // Invoice ID
 ```

--- a/api-reference/invoices/retry.mdx
+++ b/api-reference/invoices/retry.mdx
@@ -32,7 +32,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.retry_payment('__INVOICE_ID__') // Invoice ID
 ```

--- a/api-reference/invoices/update.mdx
+++ b/api-reference/invoices/update.mdx
@@ -64,7 +64,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.invoices.update({
   lago_id: "__INVOICE_ID__",

--- a/api-reference/organizations/update.mdx
+++ b/api-reference/organizations/update.mdx
@@ -77,7 +77,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 update_params = {
   timezone: 'America/New_York',

--- a/api-reference/plans/create.mdx
+++ b/api-reference/plans/create.mdx
@@ -483,7 +483,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 plan = {
   name: 'Startup',

--- a/api-reference/plans/destroy.mdx
+++ b/api-reference/plans/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.plans.destroy('code')
 ```

--- a/api-reference/plans/get-all-plans.mdx
+++ b/api-reference/plans/get-all-plans.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.plans.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/plans/get-specific.mdx
+++ b/api-reference/plans/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.plans.get('code')
 ```

--- a/api-reference/plans/update.mdx
+++ b/api-reference/plans/update.mdx
@@ -470,7 +470,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 plan = {
   name: 'plan name',

--- a/api-reference/subscriptions/assign-plan.mdx
+++ b/api-reference/subscriptions/assign-plan.mdx
@@ -165,7 +165,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.subscriptions.create(
   external_customer_id: "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",

--- a/api-reference/subscriptions/get-all.mdx
+++ b/api-reference/subscriptions/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.subscriptions.get_all({ external_customer_id: '123'})
 ```

--- a/api-reference/subscriptions/get-specific.mdx
+++ b/api-reference/subscriptions/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.subscriptions.get('external_id')
 ```

--- a/api-reference/subscriptions/terminate.mdx
+++ b/api-reference/subscriptions/terminate.mdx
@@ -30,7 +30,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 client.subscriptions.destroy("5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba")
 ```
 

--- a/api-reference/subscriptions/update.mdx
+++ b/api-reference/subscriptions/update.mdx
@@ -153,7 +153,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 update_params = { name: 'new name', subscription_at: '2022-08-08T00:00:00Z', ending_at: '2022-08-08T00:00:00Z' }
 client.subscriptions.update(update_params, 'id')

--- a/api-reference/taxes/create.mdx
+++ b/api-reference/taxes/create.mdx
@@ -48,7 +48,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 tax = {
 	name: "TVA",

--- a/api-reference/taxes/destroy.mdx
+++ b/api-reference/taxes/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.taxes.destroy('code')
 ```

--- a/api-reference/taxes/get-all.mdx
+++ b/api-reference/taxes/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.taxes.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/taxes/get-specific.mdx
+++ b/api-reference/taxes/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.taxes.get('code')
 ```

--- a/api-reference/taxes/update.mdx
+++ b/api-reference/taxes/update.mdx
@@ -48,7 +48,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 tax = {
 	name: "TVA",

--- a/api-reference/wallets/create.mdx
+++ b/api-reference/wallets/create.mdx
@@ -52,7 +52,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallets.create({
     name: 'Prepaid',

--- a/api-reference/wallets/get-all-transactions.mdx
+++ b/api-reference/wallets/get-all-transactions.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallet_transactions.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/wallets/get-all.mdx
+++ b/api-reference/wallets/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallets.get_all({ external_customer_id: hooli_1234, per_page: 2, page: 3 })
 ```

--- a/api-reference/wallets/get-specific.mdx
+++ b/api-reference/wallets/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallets.get('id')
 ```

--- a/api-reference/wallets/terminate.mdx
+++ b/api-reference/wallets/terminate.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallets.destroy('id')
 ```

--- a/api-reference/wallets/top-up.mdx
+++ b/api-reference/wallets/top-up.mdx
@@ -44,7 +44,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallet_transactions.create({
     wallet_id: 'wallet_1234',

--- a/api-reference/wallets/update.mdx
+++ b/api-reference/wallets/update.mdx
@@ -42,7 +42,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.wallets.update({
     name: 'Prepaid Credits',

--- a/api-reference/webhook-endpoints/create.mdx
+++ b/api-reference/webhook-endpoints/create.mdx
@@ -42,7 +42,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.webhook_endpoints.create({
     webhook_url: 'https://foo.bar',

--- a/api-reference/webhook-endpoints/destroy.mdx
+++ b/api-reference/webhook-endpoints/destroy.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.webhook_endpoints.destroy('id')
 ```

--- a/api-reference/webhook-endpoints/get-all.mdx
+++ b/api-reference/webhook-endpoints/get-all.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.webhook_endpoints.get_all({ per_page: 2, page: 3 })
 ```

--- a/api-reference/webhook-endpoints/get-specific.mdx
+++ b/api-reference/webhook-endpoints/get-specific.mdx
@@ -29,7 +29,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.webhook_endpoints.get('id')
 ```

--- a/api-reference/webhook-endpoints/update.mdx
+++ b/api-reference/webhook-endpoints/update.mdx
@@ -42,7 +42,7 @@ except LagoApiError as e:
 ```ruby Ruby
 require 'lago-ruby-client'
 
-client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})
+client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
 
 client.webhook_endpoints.update({
     webhook_url: 'https://foo.bar',


### PR DESCRIPTION
This PR corrects the documentation for initializing the `Lago::Api::Client` class. The previous example used an outdated syntax for passing the API key.

## Changes
- Updated the example from:
  ```ruby
  client = Lago::Api::Client.new({api_key: '__YOUR_API_KEY__'})

- to:
  ```ruby
  client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
