### PR TITLE
misc(clients): Add custom url in intro snippets

### DIFF
--- a/api-reference/intro.mdx
+++ b/api-reference/intro.mdx
@@ -42,6 +42,9 @@ pip install lago-python-client
 from lago_python_client import Client
 
 client = Client(api_key='__YOUR_API_KEY__')
+
+# When self-hosting Lago
+# client =Client(api_key='__YOUR_API_KEY__', api_url='__YOUR_LAGO_URL__')
 ```
 
 </Tab>
@@ -67,6 +70,12 @@ $ gem install lago-ruby-client
 require 'lago-ruby-client'
 
 client = Lago::Api::Client.new(api_key: '__YOUR_API_KEY__')
+
+# When self-hosting Lago
+# client = Lago::Api::Client.new(
+#   api_key: '__YOUR_API_KEY__',
+#   api_url: '__YOUR_LAGO_URL__'
+# )
 ```
 
 </Tab>
@@ -103,8 +112,10 @@ const client = Client('__YOUR_API_KEY__')
   import "github.com/getlago/lago-go-client"
 
   func main() {
-    lagoClient := lago.New().
-      SetApiKey("__YOU_API_KEY__")
+    lagoClient := lago.New().SetApiKey("__YOU_API_KEY__")
+
+    // When self-hosting Lago
+    // lagoClient := lago.New().SetApiKey("__YOU_API_KEY__").SetBaseURL("__YOUR_LAGO_URL__")
   }
 ```
 


### PR DESCRIPTION
In case you're self-hosting Lago, you also need to pass the API url.

--- 

![CleanShot 2024-07-08 at 11 37 33@2x](https://github.com/getlago/lago-doc/assets/1525636/5b546c7e-d294-4e7b-a374-dcfb776305e0)
![CleanShot 2024-07-08 at 11 37 27@2x](https://github.com/getlago/lago-doc/assets/1525636/83541e0f-4cd9-4767-844c-c729b6e6e20a)
![CleanShot 2024-07-08 at 11 37 21@2x](https://github.com/getlago/lago-doc/assets/1525636/8ca4c60c-8bef-4aeb-bb7a-0120e6203f9a)
