### PR TITLE
doc(Wallet): Add metadata doc on transaction

### DIFF
--- a/guide/wallet-and-prepaid-credits/overview.mdx
+++ b/guide/wallet-and-prepaid-credits/overview.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Overview"
-description:
-  "Since usage-based charges can be calculated at the end of the billing period, you often need to wait to collect payments. With prepaid credits, you can now unlock recurring revenue opportunities for pay-as-you-go pricing models."
+description: "Since usage-based charges can be calculated at the end of the billing period, you often need to wait to collect payments. With prepaid credits, you can now unlock recurring revenue opportunities for pay-as-you-go pricing models."
 ---
 
 Prepaid credits increase predictability as they allow you to collect payments in advance and then monitor the evolution of the balance of your customer’s wallets.
@@ -18,14 +17,16 @@ Prepaid credits increase predictability as they allow you to collect payments in
     4. Choose a name for the wallet (optional);
     5. Set the credit value (e.g. 1 credit = $5);
     6. Enter the number of credits to be purchased and/or granted for free;
-    7. Determine whether the wallet transaction generates an invoice after a top-up or only following a successful payment;
-    8. Set the [expiration date](#expiration-date-and-termination) (optional); and
-    9. Click **"Add wallet & credits"** to confirm.
+    7. Define transaction metadata (optional & available only via API);
+    8. Determine whether the wallet transaction generates an invoice after a top-up or only following a successful payment;
+    9. Set the [expiration date](#expiration-date-and-termination) (optional); and
+    10. Click **"Add wallet & credits"** to confirm.
 
     <Info>
       If the currency of the customer is already defined, the currency of the wallet
       must be the same.
     </Info>
+
   </Tab>
   <Tab title="API">
     ```bash Create a credit wallet
@@ -44,20 +45,26 @@ Prepaid credits increase predictability as they allow you to collect payments in
           "granted_credits": "50.0",
           "currency": "USD",
           "expiration_at": "2022-07-07",
-          "invoice_requires_successful_payment": false
+          "invoice_requires_successful_payment": false,
+          "transaction_metadata": [
+            {
+              "key": "top-up-type",
+              "value": "manual"
+            }
+          ]
         }
       }'
     ```
+
   </Tab>
 </Tabs>
 
-   ![Creation of a wallet via the user interface](/guide/images/new-wallet.png)
+![Creation of a wallet via the user interface](/guide/images/new-wallet.png)
 
     Free credits are added to the customer's wallet instantly, while purchased
     credits are added to the wallet when payment is confirmed (see below).
 
     Each customer can only have one active wallet.
-
 
 ## Real time wallet balance[](#real-time-wallet-balance "Direct link to heading")
 
@@ -76,7 +83,6 @@ Keep track of your wallet's real-time balance. Lago provides two types of balanc
 1. **Balance:** invoiced balance, which reflects the remaining prepaid credits in your wallet. It updates each time an invoice is finalized for the customer.
 2. **Ongoing Balance:** balance accounted for current usage, including taxes, offering a real-time estimate of your balance's consumption. It refreshes every 5 minutes or upon the finalization of an invoice for the customer.
 
-
 ## Application scope[](#application-scope "Direct link to heading")
 
 Prepaid credits are deducted from the subtotal of the next invoice(s), after
@@ -87,8 +93,8 @@ tax.
 <Info>Prepaid credits do not apply to one-off invoices.</Info>
 
 ## Invoicing after successful payment option
-When enabled, this option delays issuing an invoice for a wallet top-up until a successful payment is made. If disabled, the invoice is issued immediately upon the wallet top-up, regardless of the payment status. This setting applies to all transactions for the wallet, but can be overridden for individual transactions or recurring rules.
 
+When enabled, this option delays issuing an invoice for a wallet top-up until a successful payment is made. If disabled, the invoice is issued immediately upon the wallet top-up, regardless of the payment status. This setting applies to all transactions for the wallet, but can be overridden for individual transactions or recurring rules.
 
 ## Expiration date and termination[](#expiration-date-and-termination "Direct link to heading")
 

--- a/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
+++ b/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
@@ -18,8 +18,9 @@ Payment must be made in order for credits to be added to the customer's wallet
     1. Open the **"Wallets"** tab and click **"Edit wallet"** on the right;
     2. Select **"Top up credit"**;
     3. Enter the number of credits to be purchased and/or granted for free;
-    4. Determine whether the wallet transaction generates an invoice after a top-up or only following a successful payment; and
-    5. Click **"Top up credit"** to confirm.
+    4. Define transaction metadata (optional & available only via API);
+    5. Determine whether the wallet transaction generates an invoice after a top-up or only following a successful payment; and
+    6. Click **"Top up credit"** to confirm.
 
     <Info>Coupons **do not apply** to credit purchases and top-ups.</Info>
 
@@ -37,7 +38,13 @@ Payment must be made in order for credits to be added to the customer's wallet
           "wallet_id": "wallet_1234567890",
           "paid_credits": "20.0",
           "granted_credits": "10.0",
-          "invoice_requires_successful_payment": false
+          "invoice_requires_successful_payment": false,
+          "transaction_metadata": [
+            {
+              "key": "top-up-type",
+              "value": "manual"
+            }
+          ]
         }
       }'
     ```
@@ -45,8 +52,8 @@ Payment must be made in order for credits to be added to the customer's wallet
   </Tab>
 </Tabs>
 
-
 ## Invoicing top-up after successful payment option
+
 When enabled, this option delays issuing an invoice for a wallet top-up until a successful payment is made. If disabled, the invoice is issued immediately upon the wallet top-up, regardless of the payment status.
 This setting can be applied to individual transactions.
 
@@ -60,8 +67,9 @@ You can deduct a specific number of credits from the wallet's balance. Note that
 
     1. Open the **"Wallets"** tab and click **"Edit wallet"** on the right;
     2. Select **"Void credits"**;
-    3. Enter the number of credits to void; and
-    4. Click **"Void credits"** to confirm.
+    3. Enter the number of credits to void;
+    4. Define transaction metadata (optional & available only via API); and
+    5. Click **"Void credits"** to confirm.
 
   </Tab>
   <Tab title="API">
@@ -75,7 +83,13 @@ You can deduct a specific number of credits from the wallet's balance. Note that
       --data-raw '{
         "wallet_transaction": {
           "wallet_id": "wallet_1234567890",
-          "void_credits": "20.0"
+          "void_credits": "20.0",
+          "transaction_metadata": [
+            {
+              "key": "top-up-type",
+              "value" "manual-void"
+            }
+          ]
         }
       }'
     ```
@@ -109,11 +123,12 @@ Once the interval is defined, the system will automatically perform a top-up:
 <Tabs>
   <Tab title="Dashboard">
     To setup a `interval` recurring top-up through the user interface:
-    1. Create or edit a wallet
-    2. Trigger on the option `Activate recurring top-up`
-    3. Select `interval` as recurring type
-    4. Define your interval
-    5. Define when the rule should start
+    1. Create or edit a wallet;
+    2. Trigger on the option `Activate recurring top-up`;
+    3. Select `interval` as recurring type;
+    4. Define your interval;
+    5. Define when the rule should start; and 
+    6. Define transaction metadata for the top-ups (optional & available only via API);
   </Tab>
   <Tab title="API">
     ```bash Setup an interval recurring top-up
@@ -140,7 +155,13 @@ Once the interval is defined, the system will automatically perform a top-up:
               "started_at": null,
               "paid_credits": "100.0",
               "granted_credits": "0.0",
-              "invoice_requires_successful_payment": false
+              "invoice_requires_successful_payment": false,
+              "transaction_metadata": [
+                {
+                  "key": "top-up-type",
+                  "value": "automatic"
+                }
+              ]
             }
           ]
         }
@@ -157,10 +178,11 @@ With a `threshold` trigger, set a specific number of `credits` that will trigger
 <Tabs>
   <Tab title="Dashboard">
     To setup a `interval` recurring top-up through the user interface:
-    1. Create or edit a wallet
-    2. Trigger on the option `Activate recurring top-up`
-    3. Select `threshold` as recurring type
-    4. Define the credits threshold
+    1. Create or edit a wallet;
+    2. Trigger on the option `Activate recurring top-up`;
+    3. Select `threshold` as recurring type;
+    4. Define the credits threshold; and
+    5. Define transaction metadata for the top-ups (optional & available only via API);
   </Tab>
   <Tab title="API">
     ```bash Set a recurring top-up on creation
@@ -186,7 +208,13 @@ With a `threshold` trigger, set a specific number of `credits` that will trigger
               "threshold_credits": "100.0"
               "paid_credits": "100.0",
               "granted_credits": "0.0",
-              "invoice_requires_successful_payment": true
+              "invoice_requires_successful_payment": true,
+              "transaction_metadata": [
+                {
+                  "key": "top-up-type",
+                  "value": "automatic"
+                }
+              ]
             }
           ]
         }

--- a/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
+++ b/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
@@ -84,7 +84,7 @@ You can deduct a specific number of credits from the wallet's balance. Note that
         "wallet_transaction": {
           "wallet_id": "wallet_1234567890",
           "void_credits": "20.0",
-          "transaction_metadata": [
+          "metadata": [
             {
               "key": "top-up-type",
               "value" "manual-void"

--- a/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
+++ b/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
@@ -39,7 +39,7 @@ Payment must be made in order for credits to be added to the customer's wallet
           "paid_credits": "20.0",
           "granted_credits": "10.0",
           "invoice_requires_successful_payment": false,
-          "transaction_metadata": [
+          "metadata": [
             {
               "key": "top-up-type",
               "value": "manual"


### PR DESCRIPTION
### Description

As we had the ability to define transaction_metadata at each manual or recurring top-up, here's the documentation that covers this experience.