### PR TITLE
Fixes Issue #394 : void_credits to voided_credits

### DIFF
--- a/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
+++ b/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.mdx
@@ -83,7 +83,7 @@ You can deduct a specific number of credits from the wallet's balance. Note that
       --data-raw '{
         "wallet_transaction": {
           "wallet_id": "wallet_1234567890",
-          "void_credits": "20.0",
+          "voided_credits": "20.0",
           "metadata": [
             {
               "key": "top-up-type",


### PR DESCRIPTION
   - **Branch Name:** `fix/void-credits-to-voided-credits`
   - **Commit Message:** `Fixes Issue #394: void_credits to voided_credits`
   - **Number of Commits:** 1
   - **Test Status:** No errors


      - **PR Title:** Fixes Issue #394: void_credits to voided_credits
      - **Description:** This PR addresses Issue #394, where the variable `void_credits` was mistakenly used instead of `voided_credits`. The necessary corrections have been made across all relevant files to ensure consistent naming.
      - **Issue Reference:** Closes #394
      - **Labels:** `fix`, `bug`
