### PR TITLE
fix: change old docker compose command

### DIFF
--- a/guide/self-hosted/docker.mdx
+++ b/guide/self-hosted/docker.mdx
@@ -38,7 +38,7 @@ docker compose exec api rails db:create
 docker compose exec api rails db:migrate
 
 # Start all other components
-docker-compose up
+docker compose up
 
 ```
 


### PR DESCRIPTION
Changes the old "docker-compose" command and changes it to the new "docker compose" command as it already been used in the documentation a few lines before.