### PR TITLE
fix: typo in endpoint URL for overdue balance

### DIFF
--- a/guide/customers/customer-management.mdx
+++ b/guide/customers/customer-management.mdx
@@ -158,7 +158,7 @@ The "**Billing overview**" lets you see in a glance where a customer stands in t
       ```
       </CodeGroup>
 
-      You can retrieve the customer's overdue balance via the API using [this endpoint](/api-reference/analytics/overdue-balances).
+      You can retrieve the customer's overdue balance via the API using [this endpoint](/api-reference/analytics/overdue-balance).
       <CodeGroup>
       ```bash Get customer overdue balance
       LAGO_URL="https://api.getlago.com"


### PR DESCRIPTION
The "this endpoint" link here for overdue balance was redirecting to the API welcome page rather than the actual API endpoint. 
https://docs.getlago.com/guide/customers/customer-management#monitor-the-customers-billing-status

Pointing to https://docs.getlago.com/api-reference/analytics/overdue-balances instead of https://docs.getlago.com/api-reference/analytics/overdue-balance