### PR TITLE
Net payment term missing mention to `invoice.payment_overdue` webhook

### DIFF
--- a/guide/invoicing/net-payment-term.mdx
+++ b/guide/invoicing/net-payment-term.mdx
@@ -16,7 +16,7 @@ a billing cycle spanning one month, accompanied by a net payment term of 15 days
 
 The net payment term period applies to all types of invoices, and is used to compute the payment due date.
 
-When the `payment_due_date` has passsed, the invoice is flagged as overdue (`payment_overdue` = `true`), and Lago emits an `invoice.payment_overdue`
+When the `payment_due_date` has passed, the invoice is flagged as overdue (`payment_overdue` = `true`), and Lago emits an `invoice.payment_overdue`
 [webhook message](/api-reference/webhooks/messages).
 
 The invoice stays flagged as overdue until the payment is `succeeded`, or `payment_dispute_lost_at` is applied, or the invoice is voided.

--- a/guide/invoicing/net-payment-term.mdx
+++ b/guide/invoicing/net-payment-term.mdx
@@ -14,10 +14,12 @@ a billing cycle spanning one month, accompanied by a net payment term of 15 days
 
 ## Application scope[](#application-scope "Direct link to heading")
 
-The net payment term period applies to all types of invoices. 
-It does not trigger any webhook when the `payment_due_date` becomes overdue.
+The net payment term period applies to all types of invoices, and is used to compute the payment due date.
 
-The net payment term period applies to all types of invoices and is used to compute the due date. When the `payment_due_date` has passsed, the invoice is flagged as `Overdue`. This action sets the `payment_overdue` field to true, until the payment is `succeeded`, `payment_dispute_lost_at` is applied, or the invoice is voided.
+When the `payment_due_date` has passsed, the invoice is flagged as overdue (`payment_overdue` = `true`), and Lago emits an `invoice.payment_overdue`
+[webhook message](/api-reference/webhooks/messages).
+
+The invoice stays flagged as overdue until the payment is `succeeded`, or `payment_dispute_lost_at` is applied, or the invoice is voided.
 
 ## Define a net payment term at organization level[](#define-a-net-payment-term-at-organization-level "Direct link to heading")
 


### PR DESCRIPTION
In the Invoice `Net payment Term` doc, it says that no webhook is triggered when an invoice payment becomes overdue (after the net payment term).

However [this code](https://github.com/getlago/lago-api/blob/41a994c4ffc579462f1eceff6dc64d1d0f211818/app/jobs/clock/mark_invoices_as_payment_overdue_job.rb#L24) seems to indicate that the `invoice.payment_overdue` webhook message is sent. I assume this is just an overlook in the docs ?