### PR TITLE
fix(self-hosted): Fix intialization of RSA private key

### DIFF
--- a/guide/self-hosted/docker.mdx
+++ b/guide/self-hosted/docker.mdx
@@ -27,7 +27,8 @@ git clone https://github.com/getlago/lago.git
 cd lago
 
 # Set up environment configuration
-echo "LAGO_RSA_PRIVATE_KEY=\"`openssl genrsa 2048 | base64`\"" >> .env
+echo "LAGO_RSA_PRIVATE_KEY=\"`openssl genrsa 2048 | base64 | tr -d '\n'`\"" >> .env
+
 source .env
 
 # Start the api


### PR DESCRIPTION
This PR updates the self-hosted documentation to make sure that the `LAGO_RSA_PRIVATE_KEY` will not contains carriage return as it could cause issues with some configurations

Related to https://github.com/getlago/lago/issues/389