### PR TITLE
Add some `customer.vies_check` webhook details

### DIFF
--- a/integrations/taxes/lago-eu-taxes.mdx
+++ b/integrations/taxes/lago-eu-taxes.mdx
@@ -68,3 +68,6 @@ Lago performs VIES verifications under these circumstances:
 Lago ensures transparency and compliance by logging each VIES check. This occurs whenever you create or update a customer. 
 For each check, Lago dispatches a webhook message. This allows you to record these validations for compliance purposes. 
 You can access and review any of these automated checks as needed.
+
+It's recommeneded to listen to the `customer.vies_check` webhook because a valid tax identification number can still result
+in an error due to timeout or VIES api availability. A user passing a valid number that couldn't be verified won't be exempted from VAT.


### PR DESCRIPTION
Feel free to edit the content of course

The payload of the webhook when a check failed will be somehting like this. Note that `vies_check` is nested under `customer`.

```ruby
{
  "webhook_type" => "customer.vies_check",
  "object_type"  => "customer",
  "customer"  => {
    "lago_id"  => "1c04477e-6ac8-4e79-8215-3596cc1314cf",
    # ...
    # ...
    "vies_check"  => "HASH SHOWN BELOW GOES HERE"
}
```

### When valid

The response from the VIES API is returned, like before

### When format is invalid

```json
{
  "valid": false,
  "valid_format": false,
}
```

### When format is valid but number doesn't exist

```json
{
  "valid": false,
  "valid_format": true
}
```


### When the API returned an error (timeout, rate limit and so on)

```json
{
  "valid": false,
  "valid_format": true,
  "error": "The VIES web service returned the error: <ERROR FROM VIES>"
}
```

The error message prefix is from valvat.