### PR TITLE
Feat(multientities): remove commented part

### DIFF
--- a/guide/billing_entities.mdx
+++ b/guide/billing_entities.mdx
@@ -8,7 +8,7 @@ description: "Billing entities allow organizations to have different configurati
 </Warning>
 
 <Info>
-  All organizations have at least one billing entity. Additional billing entities are available as a premium feature. The default entity for an organization is the oldest active billing entity, and it will be used for requests if no billing entity is provided.
+  All organizations must have at least one billing entity. Additional billing entities are available as a premium feature. The default entity for an organization is the oldest active billing entity, and it will be used for requests if no billing entity is provided.
 </Info>
 
 ## Overview[](#overview "Direct link to heading")
@@ -25,7 +25,10 @@ Billing entities are instances that enable organizations to:
   If no billing entity is specified for a customer, the organization's default billing entity will be used automatically.
 </Info>
 
-<!-- ## Create a Billing Entity[](#create-billing-entity "Direct link to heading")
+## Create a Billing Entity[](#create-billing-entity "Direct link to heading")
+<Warning>
+  The Billing Entities feature is currently in development. This functionality is not available yet. We are actively working on expanding this feature.
+</Warning>
 
 <Tabs>
   <Tab title="Dashboard">
@@ -55,14 +58,13 @@ Billing entities are instances that enable organizations to:
           "code": "acme_corp",
           "name": "Acme Corporation",
           "invoice_prefix": "ACM",
-          "invoice_footer": "Thank you for your business",
-          "invoice_template": "default"
+          "invoice_footer": "Thank you for your business"
         }
       }'
     ```
     </CodeGroup>
   </Tab>
-</Tabs> -->
+</Tabs>
 
 ## Create Customer with Billing Entity[](#create-customer-with-billing-entity "Direct link to heading")
 


### PR DESCRIPTION
Seems that mintify fails to compile the page if it has commented section. Uncommented code to create a billing_entity, added a mark that it's not available now