### PR TITLE
misc(self-hosted): remove unnecessary migration instructions

### DIFF
--- a/guide/self-hosted/docker.mdx
+++ b/guide/self-hosted/docker.mdx
@@ -43,14 +43,7 @@ echo "LAGO_RSA_PRIVATE_KEY=\"`openssl genrsa 2048 | base64 | tr -d '\n'`\"" >> .
 
 source .env
 
-# Start the api
-docker compose up -d api
-
-# Create the database
-docker compose exec api rails db:create
-docker compose exec api rails db:migrate
-
-# Start all other components
+# Start all the components
 docker compose up
 
 ```


### PR DESCRIPTION
Following PR https://github.com/getlago/lago/pull/428, `docker-compose` now uses service dependencies
to ensure migrations are run before the API container starts. This change removes outdated instructions and simplifies the process.