### PR TITLE
api_refs: fix swap between webhook endpoints

### DIFF
--- a/api-reference/webhook-endpoints/get-all.mdx
+++ b/api-reference/webhook-endpoints/get-all.mdx
@@ -1,7 +1,6 @@
 ---
 openapi: "GET /webhook_endpoints"
 authMethod: "bearer"
-title: "Retrieve a webhook endpoint"
 ---
 
 <RequestExample>

--- a/api-reference/webhook-endpoints/get-specific.mdx
+++ b/api-reference/webhook-endpoints/get-specific.mdx
@@ -1,7 +1,6 @@
 ---
 openapi: "GET /webhook_endpoints/{lago_id}"
 authMethod: "bearer"
-title: "List all webhook endpoints"
 ---
 
 <RequestExample>


### PR DESCRIPTION
The retrieve all webhook endpoints and the get a specific webhook endpoints were mixed up in the api refs. This is fixed with this PR