### PR TITLE
misc(docker): Checkout latest git tag

### DIFF
--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -38,6 +38,12 @@ git clone https://github.com/getlago/lago.git
 # Go to Lago folder
 cd lago
 
+# Fetch all tags
+git fetch --tags
+
+# Get the latest tag and checkout
+git checkout $(git describe --tags --abbrev=0)
+
 # Set up environment configuration
 echo "LAGO_RSA_PRIVATE_KEY=\"`openssl genrsa 2048 | base64 | tr -d '\n'`\"" >> .env
 
@@ -45,7 +51,6 @@ source .env
 
 # Start all the components
 docker compose up
-
 ```
 
 You can now open your browser and go to [http://localhost](http://localhost) to


### PR DESCRIPTION
This PR updates the self-hosted documentation to make sure that people always start the application on the last released version rather than on the main branch as it could contains some inconsistencies