### PR TITLE
misc: mention pt_BR as a newly supported document locale

### DIFF
--- a/api-reference/resources/locales.mdx
+++ b/api-reference/resources/locales.mdx
@@ -13,6 +13,7 @@ List of accepted locales for documents (ISO 639-1).
 | French | `fr` |
 | Italian | `it` |
 | Norwegian (Bokmål) | `nb` |
+| Portuguese (Brazil) | `pt_BR` |
 | Spanish | `es` |
 | Swedish | `sv` |
 


### PR DESCRIPTION
Portuguese (Brazil) `pt_BR` is now part of supported locales in the app.