### PR TITLE
Migration guide v1.32.0

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -255,6 +255,7 @@
               {
                 "group": "Migrations",
                 "pages": [
+                  "guide/migration/migration-to-v1.32.0",
                   "guide/migration/migration-to-v1.31.0",
                   "guide/migration/migration-to-v1.29.0",
                   "guide/migration/migration-to-v1.28.1",

--- a/guide/migration/migration-to-v1.32.0.mdx
+++ b/guide/migration/migration-to-v1.32.0.mdx
@@ -4,7 +4,7 @@ title: "Migration to v1.32.0"
 
 Dear Lago Community, 👋
 
-We're writing to inform you about important changes in Lago v1.32.0 that will enhance your payment management experience and introduce a new unified upgrade process.
+We're writing to inform you about important changes in Lago v1.32.0 that will enhance your payments and subscriptions management experience and introduce a new unified upgrade process.
 
 # What are the changes?
 

--- a/guide/migration/migration-to-v1.32.0.mdx
+++ b/guide/migration/migration-to-v1.32.0.mdx
@@ -1,0 +1,69 @@
+---
+title: "Migration to v1.32.0"
+---
+
+Dear Lago Community, 👋
+
+We're writing to inform you about important changes in Lago v1.32.0 that will enhance your payment management experience and introduce a new unified upgrade process.
+
+# What are the changes?
+
+## New Pages and Enhanced Functionality
+
+This version introduces several new pages including payments and subscriptions with enhanced search and filtering capabilities. The new interfaces provide detailed information and improved user experience for managing records.
+
+**Important:** To ensure the payments page displays correctly and search functionality works properly, you must run the post-upgrade rake task described below.
+
+## Unified Upgrade Process
+
+Starting from this version, all post-upgrade tasks will be executed using a single rake task: `bundle exec rails upgrade:perform_required_jobs`, simplifying the upgrade process and ensuring consistency across all installations.
+
+# Why are we doing this?
+
+These changes are made to:
+1. Provide better management capabilities for payments and subscriptions with advanced search and filtering
+2. Ensure proper data indexing and display for the new payment search functionality
+3. Streamline the upgrade process by consolidating all post-upgrade tasks into a single command
+4. Improve user experience and system maintainability
+
+# What should self-hosted users do?
+
+<Note>
+Cloud users do not need to follow these instructions as the migration will be performed by the Lago Team.
+</Note>
+
+<Warning>
+If you're using a version below `v1.20.0`, please first follow the migration steps for [v1.20.0](/guide/migration/migration-to-v1.20.0), then for [v1.25.0](/guide/migration/migration-to-v1.25.0), then for [v1.28.1](/guide/migration/migration-to-v1.28.1), then for [v1.29.0](/guide/migration/migration-to-v1.29.0), then for [v1.31.0](/guide/migration/migration-to-v1.31.0).
+Only after completing those should you proceed to v1.32.0.
+</Warning>
+
+## Migration Steps
+
+1. Install Lago v1.32.0
+2. Open a shell (bash) on your API server
+3. Run the unified upgrade task:
+
+```bash
+bundle exec rails upgrade:perform_required_jobs
+```
+
+<Note>
+This task will automatically execute all required post-upgrade jobs for this version, including the necessary data indexing for the payments page search functionality. The process runs in the background and may take some time depending on your data size.
+</Note>
+
+<Note>
+All resources are processed in background jobs to ensure system stability during the upgrade process.
+</Note>
+
+# Timeline
+
+We recommend performing this migration as soon as possible after the release of v1.32.0 to ensure optimal performance and access to the new payment and subscription management features.
+
+# Get Involved
+
+If you have any questions or encounter issues during the migration, please reach out to us via the Slack community. Our team is here to help you through this transition.
+
+Thanks for your understanding and continued support.
+
+The Lago Team
+


### PR DESCRIPTION
Upgrade to v1.32.0 will require running a rake task.

In this migration guide we're explaining what needs to be done 
and explaining that a new unified command has been added.