### PR TITLE
fix(timezones): Fix timezone names

### DIFF
--- a/api-reference/resources/timezones.mdx
+++ b/api-reference/resources/timezones.mdx
@@ -17,7 +17,6 @@ description: "List of accepted timezones (TZ database)."
 - `America/Chicago`
 - `America/Chihuahua`
 - `America/Denver`
-- `America/Godthab`
 - `America/Guatemala`
 - `America/Guyana`
 - `America/Halifax`
@@ -31,6 +30,7 @@ description: "List of accepted timezones (TZ database)."
 - `America/Monterrey`
 - `America/Montevideo`
 - `America/New_York`
+- `America/Nuuk`
 - `America/Phoenix`
 - `America/Puerto_Rico`
 - `America/Regina`
@@ -60,7 +60,6 @@ description: "List of accepted timezones (TZ database)."
 - `Asia/Magadan`
 - `Asia/Muscat`
 - `Asia/Novosibirsk`
-- `Asia/Rangoon`
 - `Asia/Riyadh`
 - `Asia/Seoul`
 - `Asia/Shanghai`
@@ -75,6 +74,7 @@ description: "List of accepted timezones (TZ database)."
 - `Asia/Urumqi`
 - `Asia/Vladivostok`
 - `Asia/Yakutsk`
+- `Asia/Yangon`
 - `Asia/Yekaterinburg`
 - `Asia/Yerevan`
 - `Atlantic/Azores`
@@ -100,7 +100,7 @@ description: "List of accepted timezones (TZ database)."
 - `Europe/Helsinki`
 - `Europe/Istanbul`
 - `Europe/Kaliningrad`
-- `Europe/Kiev`
+- `Europe/Kyiv`
 - `Europe/Lisbon`
 - `Europe/Ljubljana`
 - `Europe/London`


### PR DESCRIPTION
## Context

Related to https://github.com/getlago/lago-api/pull/4177

Following the update of Ruby to version 3.4.5, some issues where spotted in the timezone especially when exporting the Timezone enum for the GraphQL API.

It appears that some zone were renamed in ruby but that the support for rails has not yet been changed accordingly.

## Description

This PR updates the timezones names in the documentation
  - Asia/Rangoon => Asia/Yangon
  - Europe/Kiev => Europe/Kyiv
  - America/Godthab => America/Nuuk

