### PR TITLE
feat: Add documentation for min/max expressions

### DIFF
--- a/guide/billable-metrics/sql-expressions.mdx
+++ b/guide/billable-metrics/sql-expressions.mdx
@@ -84,6 +84,7 @@ A variety of SQL custom expressions are available for use. Here are a few exampl
 - **Concatenation:** `CONCAT(event.properties.user_id, '-', event.properties.app_id)`
 - **Math operations:** `(event.properties.cpu_number * 25 * event.properties.duration_msec) + (event.properties.memory_mb * 0.000001 * event.properties.duration_msec)`
 - **Rounding:** `ROUND(event.properties.duration_msec * 1000)`
+- **Min/Max:** `MIN(event.properties.memory_mb, 10.0)`
 
 You can find the full list of supported expressions below:
 
@@ -95,6 +96,8 @@ You can find the full list of supported expressions below:
   - [`ROUND`](#ROUND)
   - [`FLOOR`](#FLOOR)
   - [`CEIL`](#CEIL)
+  - [`MIN`](#MIN)
+  - [`MAX`](#MAX)
 
 If you need a custom expression that isn't supported by default in Lago, **feel free to contact our team** or **consider contributing to the open-source version**.
 
@@ -205,6 +208,42 @@ CEIL(value, precision)
 - `CEIL(14.2345, 0)` returns `15`
 - `CEIL(14.2345, 2)` returns `14.24`
 - `CEIL(14.2345, -1)` returns `20`
+
+#### `MIN`
+
+The `MIN` function is used to find minimum of two or more numbers.
+
+```SQL
+MIN(num1, num2[,nums,...])
+```
+
+**Parameters:**
+- `num1`: The first number to check minimum value
+- `num2`: The second number to check minimum value
+- `nums`: (Optional) Additional numbers to check minimum value.
+
+**Returns:** The minimum of the given numbers.
+
+**Examples:**
+- `MIN(event.properties.disk1_usage_mb, event.properties.disk2_usage_mb, 10.0)`
+
+#### `MAX`
+
+The `MAX` function is used to find maximum of two or more numbers.
+
+```SQL
+MAX(num1, num2[,nums,...])
+```
+
+**Parameters:**
+- `num1`: The first number to check minimum value
+- `num2`: The second number to check minimum value
+- `nums`: (Optional) Additional numbers to check minimum value.
+
+**Returns:** The maximum of the given numbers.
+
+**Examples:**
+- `MAX(event.properties.memory_mb, 10.0)`
 
 ## Testing your SQL Custom Expression
 Lago provides a testing tool to help you validate the custom expressions you've created. A sample event is used to test your expression. You can override any field in the test event.


### PR DESCRIPTION
I created a [PR](https://github.com/getlago/lago-expression/pull/17)  to add support for `MIN/MAX` in billable metrics custom expressions. This PR is for adding the relevant documentation. Please take a look at both PRs.

If you accept the `lago-expression` PR, then I can also create the PR for updating gem version for `lago-expression` in Lago API repo and npm package version for `lago-expression` in Lago Front repo.
