### PR TITLE
bug: locale with language and country uses dash notation

### DIFF
--- a/api-reference/resources/locales.mdx
+++ b/api-reference/resources/locales.mdx
@@ -13,7 +13,7 @@ List of accepted locales for documents (ISO 639-1).
 | French | `fr` |
 | Italian | `it` |
 | Norwegian (Bokmål) | `nb` |
-| Portuguese (Brazil) | `pt_BR` |
+| Portuguese (Brazil) | `pt-BR` |
 | Spanish | `es` |
 | Swedish | `sv` |
 


### PR DESCRIPTION
Locales using the 4 digit notation for locale + country should use the dash notation.

This [have been changed recently](https://github.com/getlago/lago-api/pull/4233) in our application and I forgot to update the doc.

So `pr_BR` should be `pt-BR`