### PR TITLE
permissions: remove subscription delete

### DIFF
--- a/guide/security/rbac.mdx
+++ b/guide/security/rbac.mdx
@@ -56,8 +56,7 @@ subscriptions. It's ideal for analyzing financial data, reviewing invoices, and 
 | Subscriptions     | view                 | Access subscriptions                            | ✅    | ✅      | ✅      |
 | Subscriptions     | create               | Assign a New Plan                               | ✅    | ✅      | ❌      |
 | Subscriptions     | update               | Edit subscription                               | ✅    | ✅      | ❌      |
-| Subscriptions     | update               | Upgrade/downgrade                               | ✅    | ✅      | ❌      |
-| Subscriptions     | delete               | Delete subscription                             | ✅    | ✅      | ❌      |
+| Subscriptions     | update               | Upgrade, Downgrade, Terminate                   | ✅    | ✅      | ❌      |
 | Wallets           | create               | Create a Wallet                                 | ✅    | ✅      | ❌      |
 | Wallets           | update               | Edit a Wallet                                   | ✅    | ✅      | ❌      |
 | Wallets           | top_up               | Top-up a Wallet                                 | ✅    | ✅      | ❌      |


### PR DESCRIPTION
A subscription can be terminated but not deleted. To terminate it, we check for `subscriptions:update` permission.