### PR TITLE
nit: Convert Tabs to CodeGroups on OpenAI template page

### DIFF
--- a/templates/per-token/openai.mdx
+++ b/templates/per-token/openai.mdx
@@ -450,11 +450,9 @@ For OpenAI, pricing depends on the language model used. Here are several price p
     2. Reference the customer's subscription with `external_subscription_id`
     3. Include usage and filters data in `properties`
 
-    <Tabs>
+    <CodeGroup>
 
-    <Tab title="cURL">
-
-    ```bash highlight={10,11,12-16}
+    ```bash cURL highlight={10,11,12-16}
     LAGO_URL="https://api.getlago.com"
     API_KEY="__API_KEY__"
 
@@ -475,11 +473,7 @@ For OpenAI, pricing depends on the language model used. Here are several price p
       }'
     ```
 
-    </Tab>
-
-    <Tab title="Python">
-
-    ```python highlight={9,10-15}
+    ```python Python highlight={9,10-15}
     from lago_python_client.client import Client
     from lago_python_client.exceptions import LagoApiError
     from lago_python_client.models import Event
@@ -503,11 +497,7 @@ For OpenAI, pricing depends on the language model used. Here are several price p
         repair_broken_state(e)  # do something on error or raise your own exception
     ```
 
-    </Tab>
-
-    <Tab title="Ruby">
-
-    ```ruby highlight={7,8-13}
+    ```ruby Ruby highlight={7,8-13}
     require 'lago-ruby-client'
 
     client = Lago::Api::Client.new(api_key: '__API_KEY__')
@@ -524,11 +514,7 @@ For OpenAI, pricing depends on the language model used. Here are several price p
     )
     ```
 
-    </Tab>
-
-    <Tab title="Javascript">
-
-    ```js highlight={4,5-10}
+    ```js Javascript highlight={4,5-10}
     await client.events.createEvent({
       event: {
         transaction_id: "__TRANSACTION_ID__",
@@ -543,11 +529,7 @@ For OpenAI, pricing depends on the language model used. Here are several price p
     });
     ```
 
-    </Tab>
-
-    <Tab title="Go">
-
-    ```go highlight={10-16}
+    ```go Go highlight={10-16}
     eventInput := &lago.EventInput{
       TransactionID:          "__TRANSACTION_ID__",
       Code:                   "__BILLABLE_METRIC_CODE__",
@@ -562,9 +544,7 @@ For OpenAI, pricing depends on the language model used. Here are several price p
     event, err := client.Event().Create(ctx, eventInput)
     ```
 
-    </Tab>
-
-    </Tabs>
+    </CodeGroup>
 
     Refer to the [API reference](/api-reference/events/usage) to create an event.
   </Step>


### PR DESCRIPTION
Noticed this page used CodeGroups to do tabs on all but one step which created inconsistent visuals and caused tabs to not change across this step (ex. User selects Javascript in Step 1 and it didn't reflect the selection in Step 6). Fixed that step.

Before:
<img width="721" height="425" alt="image" src="https://github.com/user-attachments/assets/e110e076-b135-4ec8-9fff-f6a223017f90" />

After:
<img width="686" height="375" alt="After" src="https://github.com/user-attachments/assets/7207d49b-7e52-46a2-b17c-734ae743738f" />