### PR TITLE
fix(404 doc): Github page points to a 404 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lago Documentation
 
-The Lago documentation is available at [doc.getlago.com](https://getlago.com/docs/).
+The Lago documentation is available at [getlago.com/docs](https://getlago.com/docs/).
 
 ## Current Releases
 


### PR DESCRIPTION
## Context

Fix dead link on the GitHub page by updating the URL to the correct documentation at https://getlago.com/docs

<!-- Linear link -->
Fixes ISSUE-1317