### PR TITLE
feat: Add documentation for least/greatest expressions

### DIFF
--- a/guide/billable-metrics/sql-expressions.mdx
+++ b/guide/billable-metrics/sql-expressions.mdx
@@ -84,7 +84,7 @@ A variety of SQL custom expressions are available for use. Here are a few exampl
 - **Concatenation:** `CONCAT(event.properties.user_id, '-', event.properties.app_id)`
 - **Math operations:** `(event.properties.cpu_number * 25 * event.properties.duration_msec) + (event.properties.memory_mb * 0.000001 * event.properties.duration_msec)`
 - **Rounding:** `ROUND(event.properties.duration_msec * 1000)`
-- **Min/Max:** `MIN(event.properties.memory_mb, 10.0)`
+- **Least/Greatest:** `LEAST(event.properties.memory_mb, 10.0)`
 
 You can find the full list of supported expressions below:
 
@@ -96,8 +96,8 @@ You can find the full list of supported expressions below:
   - [`ROUND`](#ROUND)
   - [`FLOOR`](#FLOOR)
   - [`CEIL`](#CEIL)
-  - [`MIN`](#MIN)
-  - [`MAX`](#MAX)
+  - [`LEAST`](#LEAST)
+  - [`GREATEST`](#GREATEST)
 
 If you need a custom expression that isn't supported by default in Lago, **feel free to contact our team** or **consider contributing to the open-source version**.
 
@@ -209,12 +209,12 @@ CEIL(value, precision)
 - `CEIL(14.2345, 2)` returns `14.24`
 - `CEIL(14.2345, -1)` returns `20`
 
-#### `MIN`
+#### `LEAST`
 
-The `MIN` function is used to find minimum of two or more numbers.
+The `LEAST` function is used to find minimum of two or more numbers.
 
 ```SQL
-MIN(num1, num2[,nums,...])
+LEAST(num1, num2[,nums,...])
 ```
 
 **Parameters:**
@@ -225,25 +225,25 @@ MIN(num1, num2[,nums,...])
 **Returns:** The minimum of the given numbers.
 
 **Examples:**
-- `MIN(event.properties.disk1_usage_mb, event.properties.disk2_usage_mb, 10.0)`
+- `LEAST(event.properties.disk1_usage_mb, event.properties.disk2_usage_mb, 10.0)`
 
-#### `MAX`
+#### `GREATEST`
 
-The `MAX` function is used to find maximum of two or more numbers.
+The `GREATEST` function is used to find maximum of two or more numbers.
 
 ```SQL
-MAX(num1, num2[,nums,...])
+GREATEST(num1, num2[,nums,...])
 ```
 
 **Parameters:**
-- `num1`: The first number to check minimum value
-- `num2`: The second number to check minimum value
-- `nums`: (Optional) Additional numbers to check minimum value.
+- `num1`: The first number to check maximum value
+- `num2`: The second number to check maximum value
+- `nums`: (Optional) Additional numbers to check maximum value.
 
 **Returns:** The maximum of the given numbers.
 
 **Examples:**
-- `MAX(event.properties.memory_mb, 10.0)`
+- `GREATEST(event.properties.memory_mb, 10.0)`
 
 ## Testing your SQL Custom Expression
 Lago provides a testing tool to help you validate the custom expressions you've created. A sample event is used to test your expression. You can override any field in the test event.


### PR DESCRIPTION
This PR updates the documentation from the external contribution at https://github.com/getlago/lago-doc/pull/454 following the renaming from https://github.com/getlago/lago-expression/pull/20.

It documents the new `LEAST` and `GREATEST` functions (previously `MIN` and `MAX`)