### PR TITLE
Mark Lago EU Taxes as community-maintained integration

### DIFF
--- a/integrations/introduction.mdx
+++ b/integrations/introduction.mdx
@@ -326,7 +326,7 @@ description:
     customers.
 
     <br />
-    <Tooltip tip="This integration is maintained by Lago.">Official</Tooltip>
+    <Tooltip tip="This integration is maintained by the community.">Community</Tooltip>
   </Card>
 </CardGroup>
 

--- a/integrations/taxes/lago-eu-taxes.mdx
+++ b/integrations/taxes/lago-eu-taxes.mdx
@@ -4,6 +4,10 @@ title: "Lago EU Taxes"
 
 Lago now features an automatic European tax detection integration for your customers.
 
+<Info>
+  **Lago EU Taxes is a community-maintained integration.** It covers very basic European tax scenarios, but may not address every edge case or jurisdiction. If you need a complete, production-grade tax setup, we recommend using a dedicated tax provider like [Anrok](/integrations/taxes/anrok) or [Avalara](/integrations/taxes/avalara), which are natively integrated with Lago.
+</Info>
+
 ## Enable Lago's EU Tax integration
 Activate Lago's automatic EU tax detection in just a few steps:
 


### PR DESCRIPTION
## Summary
- Added an info callout on the Lago EU Taxes page noting it is a community-maintained integration that covers basic EU tax scenarios, and recommending Anrok or Avalara for complete tax setups.
- Updated the integration badge on the integrations overview page from "Official" to "Community".

## Test plan
- [ ] Verify the info callout renders correctly on the Lago EU Taxes page
- [ ] Verify the integration card on the integrations overview shows "Community" badge
- [ ] Confirm links to Anrok and Avalara pages work