### PR TITLE
docs: Add Instructions section to llms.txt for AI coding assistants

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,409 @@
+# Lago
+
+> Lago is an open-source, API-first billing platform for usage-based and hybrid pricing models.
+> Self-hosted or cloud. Real-time event processing, flexible plan configuration, and automated invoicing.
+
+## Instructions
+
+- Lago uses Bearer token authentication. Include `Authorization: Bearer YOUR_API_KEY` in all requests.
+- Cloud API base URL: `https://api.getlago.com/api/v1`
+- Self-hosted: same API, your own base URL. API behavior is identical.
+- The correct integration flow for usage-based billing is:
+  1. Create a billable metric (defines what you measure — e.g., API calls, tokens, GB stored)
+  2. Create a plan with charges referencing that metric (set pricing model: graduated, package, volume, percentage)
+  3. Create a customer
+  4. Create a subscription linking the customer to the plan
+  5. Push usage events via the Events API
+- Always include an idempotency key (`transaction_id`) when pushing events to prevent duplicate billing.
+- Use the Events API for all metering — never write usage data directly.
+- For batch ingestion, use the batch events endpoint (up to 100 events per request).
+- Payment collection: configure payment providers (Stripe, Adyen, GoCardless) via Lago's payment provider endpoints — do not integrate with payment providers directly.
+- For prepaid credits: create a wallet for the customer, then top it up. Usage automatically draws down from the wallet balance.
+- Webhooks are the recommended way to react to billing events (invoice.created, payment_request.payment_failure, etc.). Configure webhook endpoints via the API or UI.
+- Lago supports multiple pricing models in a single plan: flat fees, graduated tiers, package pricing, volume discounts, and percentage-based charges.
+
+## Docs
+
+- [The add-on object](https://docs.getlago.com/api-reference/add-ons/add-on-object.md): This object represents an add-on, a one-time fee that can be applied on one-off invoices.
+- [Create an add-on](https://docs.getlago.com/api-reference/add-ons/create.md): This endpoint is used to create an add-on that can be then attached to a one-off invoice.
+- [Delete an add-on](https://docs.getlago.com/api-reference/add-ons/destroy.md): This endpoint is used to delete an existing add-on.
+- [List all add-ons](https://docs.getlago.com/api-reference/add-ons/get-all.md): This endpoint is used to list all existing add-ons.
+- [Retrieve an add-on](https://docs.getlago.com/api-reference/add-ons/get-specific.md): This endpoint is used to retrieve a specific add-on.
+- [Update an add-on](https://docs.getlago.com/api-reference/add-ons/update.md): This endpoint is used to update an existing add-on.
+- [The alert object](https://docs.getlago.com/api-reference/alerts/alert-object.md): This object represents an alert to monitor your subscriptions' usage and billing by firing notifications when certain conditions are met.
+- [Create an alert](https://docs.getlago.com/api-reference/alerts/create.md): This endpoint allows you to create a new alert for a subscription.
+- [Delete an alert](https://docs.getlago.com/api-reference/alerts/delete.md): This endpoint allows you to delete an existing alert for a subscription.
+- [List all alerts](https://docs.getlago.com/api-reference/alerts/get-all.md): This endpoint allows you to retrieve all alerts for a subscription.
+- [Retrieve an alert](https://docs.getlago.com/api-reference/alerts/get-specific.md): This endpoint allows you to retrieve a specific alert for a subscription.
+- [Update an alert](https://docs.getlago.com/api-reference/alerts/update.md): This endpoint allows you to update an existing alert for a subscription.
+- [API standards](https://docs.getlago.com/api-reference/api-standards.md)
+- [The activity log object](https://docs.getlago.com/api-reference/audit-logs/activity-logs-object.md): This object represents an activity log entry of any actions performed on application resources.
+- [The API log object](https://docs.getlago.com/api-reference/audit-logs/api-logs-object.md): This object represents an API log entry of any actions performed through the API endpoints.
+- [List all activity logs](https://docs.getlago.com/api-reference/audit-logs/get-all-activity-logs.md): This endpoint retrieves all existing activity logs that represent actions performed on application resources.
+- [List all API logs](https://docs.getlago.com/api-reference/audit-logs/get-all-api-logs.md): This endpoint retrieves all existing api logs that represent requests performed to Lago's API.
+- [Retrieve an activity log](https://docs.getlago.com/api-reference/audit-logs/get-specific-activity-log.md): This endpoint retrieves an existing activity log that represents an action performed on some resource. The activity log is identified by its unique activity_id.
+- [Retrieve an API log](https://docs.getlago.com/api-reference/audit-logs/get-specific-api-log.md): This endpoint retrieves an existing api log that represents a request made to the API. The api log is identified by its unique request_id.
+- [Create a billable metric](https://docs.getlago.com/api-reference/billable-metrics/create.md): This endpoint creates a new billable metric representing a pricing component of your application.
+- [Delete a billable metric](https://docs.getlago.com/api-reference/billable-metrics/destroy.md): This endpoint deletes an existing billable metric representing a pricing component of your application.
+- [List all billable metrics](https://docs.getlago.com/api-reference/billable-metrics/get-all.md): This endpoint retrieves all existing billable metrics that represent pricing components of your application.
+- [Retrieve a billable metric](https://docs.getlago.com/api-reference/billable-metrics/get-specific.md): This endpoint retrieves an existing billable metric that represents a pricing component of your application. The billable metric is identified by its unique code.
+- [The billable metric object](https://docs.getlago.com/api-reference/billable-metrics/object.md): This object represents a billable metric used to define how incoming events are aggregated in order to measure consumption.
+- [Update a billable metric](https://docs.getlago.com/api-reference/billable-metrics/update.md): This endpoint updates an existing billable metric representing a pricing component of your application.
+- [Create a billing entity](https://docs.getlago.com/api-reference/billing-entities/create.md): This endpoint is used to create a new billing entity
+- [List all billing entities](https://docs.getlago.com/api-reference/billing-entities/get-all.md): This endpoint returns a list of all billing entities in the organization
+- [Retrieve a billing entity](https://docs.getlago.com/api-reference/billing-entities/get-specific.md): This endpoint returns a specific billing entity by its code
+- [The billing entity object](https://docs.getlago.com/api-reference/billing-entities/object.md): This object represents a billing entity used to generate invoices.
+- [Update a billing entity](https://docs.getlago.com/api-reference/billing-entities/update.md): This endpoint is used to update an existing billing entity
+- [The applied coupon object](https://docs.getlago.com/api-reference/coupons/applied-coupon-object.md): This object represents a coupon applied to a customer. It can override the initial values of a coupon.
+- [Apply a coupon](https://docs.getlago.com/api-reference/coupons/apply.md): This endpoint is used to apply a specific coupon to a customer, before or during a subscription.
+- [The coupon object](https://docs.getlago.com/api-reference/coupons/coupon-object.md): This object represents a coupon used to applies discount on customer next invoices. This coupon can be applied to a customer with overriden values.
+- [Create a coupon](https://docs.getlago.com/api-reference/coupons/create.md): This endpoint is used to create a coupon that can be then attached to a customer to create a discount.
+- [Delete a coupon](https://docs.getlago.com/api-reference/coupons/destroy.md): This endpoint is used to delete a coupon.
+- [Delete an applied coupon](https://docs.getlago.com/api-reference/coupons/destroy-applied-coupon.md): This endpoint is used to delete a specific coupon that has been applied to a customer.
+- [List all coupons](https://docs.getlago.com/api-reference/coupons/get-all.md): This endpoint is used to list all existing coupons.
+- [List all applied coupons](https://docs.getlago.com/api-reference/coupons/get-all-applied.md): This endpoint is used to list all applied coupons. You can filter by coupon status and by customer.
+- [Retrieve a coupon](https://docs.getlago.com/api-reference/coupons/get-specific.md): This endpoint is used to retrieve a specific coupon.
+- [Update a coupon](https://docs.getlago.com/api-reference/coupons/update.md): This endpoint is used to update a coupon that can be then attached to a customer to create a discount.
+- [Create a credit note](https://docs.getlago.com/api-reference/credit-notes/create.md): This endpoint creates a new credit note.
+- [The credit note object](https://docs.getlago.com/api-reference/credit-notes/credit-note-object.md): This object represents a credit note, used to refund or credit back a customer for a fee or an invoice.
+- [Download a credit note](https://docs.getlago.com/api-reference/credit-notes/download.md): This endpoint downloads the PDF of an existing credit note.
+- [Estimate a credit note](https://docs.getlago.com/api-reference/credit-notes/estimate.md): This endpoint allows you to retrieve amounts for a new credit note creation.
+- [List all credit notes](https://docs.getlago.com/api-reference/credit-notes/get-all.md): This endpoint list all existing credit notes.
+- [Retrieve a credit note](https://docs.getlago.com/api-reference/credit-notes/get-specific.md): This endpoint retrieves an existing credit note.
+- [Replace all metadata](https://docs.getlago.com/api-reference/credit-notes/metadata/create-metadata-cn.md): This endpoint replaces all existing metadata on a credit note with the provided key-value pairs. Any existing metadata keys not included in the request will be removed.
+- [Delete a metadata](https://docs.getlago.com/api-reference/credit-notes/metadata/delete-a-metadata-cn.md): This endpoint removes a single metadata key from a credit note.
+- [Delete all metadata](https://docs.getlago.com/api-reference/credit-notes/metadata/delete-all-metadata-cn.md): This endpoint removes all metadata from a credit note.
+- [Udpate metadata](https://docs.getlago.com/api-reference/credit-notes/metadata/update-metadata-cn.md): This endpoint merges the provided metadata with existing metadata on the credit note. Existing keys not in the request are preserved. New keys are added, existing keys are updated.
+- [Update a credit note](https://docs.getlago.com/api-reference/credit-notes/update.md): This endpoint updates an existing credit note.
+- [Void available credit](https://docs.getlago.com/api-reference/credit-notes/void.md): This endpoint voids the available credit linked to a specific credit note.
+- [The customer usage object](https://docs.getlago.com/api-reference/customer-usage/customer-usage-object.md): This object represents the usage-based charges associated with one of your customers for a defined billing period. It allows you to monitor customer usage throughout the period.
+- [Retrieve current usage](https://docs.getlago.com/api-reference/customer-usage/get-current.md): Retrieve real-time customer usage data for the current open billing period.
+- [Retrieve past usage](https://docs.getlago.com/api-reference/customer-usage/get-past.md): Fetch historical customer usage data for closed billing periods.
+- [Retrieve projected usage](https://docs.getlago.com/api-reference/customer-usage/get-projected.md): Retrieve real-time projected usage data for the current open billing period.
+- [Create a customer](https://docs.getlago.com/api-reference/customers/create.md): This endpoint creates a new customer.
+- [Retrieve customer portal URL](https://docs.getlago.com/api-reference/customers/customer-portal.md): Retrieves an embeddable link for displaying a customer portal.
+- [Delete a customer](https://docs.getlago.com/api-reference/customers/delete.md): This endpoint deletes an existing customer.
+- [List all customers](https://docs.getlago.com/api-reference/customers/get-all.md): This endpoint retrieves all existing customers.
+- [Retrieve a customer](https://docs.getlago.com/api-reference/customers/get-specific.md): This endpoint retrieves an existing customer.
+- [The customer object](https://docs.getlago.com/api-reference/customers/object.md): This object represents a customer of your business. It lets you create or update a customer, but also track usage and create invoices for the same customer.
+- [Regenerate checkout URL](https://docs.getlago.com/api-reference/customers/psp-checkout-url.md): This endpoint regenerates the Payment Provider Checkout URL of a Customer.
+- [Update a customer](https://docs.getlago.com/api-reference/customers/update.md): This endpoint creates a new customer.
+- [Create a feature](https://docs.getlago.com/api-reference/entitlements/features/create-feature.md): This endpoint creates a new feature representing an entitlement component of your application.
+- [Delete a feature](https://docs.getlago.com/api-reference/entitlements/features/delete-feature.md): This endpoint deletes an existing feature representing an entitlement component of your application. Deleting a feature will remove it from all plans and subscriptions.
+- [Delete a feature privilege](https://docs.getlago.com/api-reference/entitlements/features/delete-privilege.md): Delete privilege from feature. Deleting a privilege removes it from all plans and subscriptions.
+- [The feature object](https://docs.getlago.com/api-reference/entitlements/features/feature-object.md): This object represents a feature of your business, that can be entitled to a customer through a plan or a subscription.
+- [List all features](https://docs.getlago.com/api-reference/entitlements/features/get-all-features.md): This endpoint retrieves all existing features that represent entitlement components of your application.
+- [Retrieve a feature](https://docs.getlago.com/api-reference/entitlements/features/get-feature.md): This endpoint retrieves an existing feature that represents an entitlement component of your application. The feature is identified by its unique code.
+- [Update a feature](https://docs.getlago.com/api-reference/entitlements/features/update-feature.md): This endpoint updates an existing feature representing an entitlement component of your application.
+- [Create plan entitlements](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/create-plan-entitlement.md): This endpoint creates new entitlements by adding features to a plan. Note that all existing entitlements will be deleted and replaced by the ones provided. To add a new entitlement without removing the existing ones, use PATCH. The feature must exist and all privileges must be valid for the feature.
+- [Delete a plan entitlement](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/delete-plan-entitlement.md): This endpoint deletes an existing entitlement by removing the feature from the plan.
+- [Delete a plan entitlement privilege](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/delete-plan-entitlement-privilege.md): This endpoint removes a specific privilege and its value from an entitlement. The privilege remains untouched on the original feature.
+- [List plan entitlements](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/get-all-plan-entitlements.md): This endpoint retrieves all entitlements for a specific plan.
+- [Retrieve a plan entitlement](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/get-specific-plan-entitlement.md): This endpoint retrieves a specific entitlement for a plan.
+- [The plan entitlement object](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/plan-entitlement-object.md): This object represents entitlements belonging to a plan.
+- [Update plan entitlements](https://docs.getlago.com/api-reference/entitlements/plan-entitlements/update-plan-entitlement.md): This accepts a list of entitlements to update. If the feature isn't part of the plan yet, it's added with all the privileges from the payload. If the feature is already part of the plan, the privilege and values are updated or added. All privileges must be valid for the feature. All features  and pr…
+- [Delete a subscription entitlement](https://docs.getlago.com/api-reference/entitlements/subscription-entitlements/delete-subscription-entitlement.md): This endpoint removes a specific feature entitlement from a subscription. The entitlement remains available from the plan.
+- [Delete a subscription entitlement privilege](https://docs.getlago.com/api-reference/entitlements/subscription-entitlements/delete-subscription-entitlement-privilege.md): This endpoint removes a specific privilege from a subscription entitlement. The privilege entitlement remains available from the plan.
+- [List subscription entitlements](https://docs.getlago.com/api-reference/entitlements/subscription-entitlements/get-all-subscription-entitlements.md): This endpoint retrieves all entitlements for a specific subscription, including both plan entitlements and any subscription-specific overrides.
+- [The subscription entitlement object](https://docs.getlago.com/api-reference/entitlements/subscription-entitlements/subscription-entitlement-object.md): This object represents entitlements belonging to a subscription.
+- [Update subscription entitlements](https://docs.getlago.com/api-reference/entitlements/subscription-entitlements/update-subscription-entitlement.md): This accepts a list of entitlements to update. If the feature isn't part of the subscription yet, it's added with all the privileges from the payload. If the feature is already part of the subscription (via plan or via override), the privilege and values are updated or added. All privileges must be…
+- [Errors](https://docs.getlago.com/api-reference/errors.md)
+- [Batch usage events](https://docs.getlago.com/api-reference/events/batch.md): This endpoint can be used to send a batch of usage records. Each request may include up to 100 events.
+- [Estimate an upcoming fee](https://docs.getlago.com/api-reference/events/estimated-fee.md): Estimate the fees that would be created after reception of an event for a billable metric attached to one or multiple pay in advance charges.
+- [The event object](https://docs.getlago.com/api-reference/events/event-object.md): Events represents usage measurement sent to lago application that will then be aggregated into invoice line items.
+- [Retrieve an event](https://docs.getlago.com/api-reference/events/get-specific.md): This endpoint is used for retrieving a specific usage measurement event that has been sent to a customer or a subscription.
+- [List all events](https://docs.getlago.com/api-reference/events/list-events.md): This endpoint is used for retrieving all events.
+- [Send usage event](https://docs.getlago.com/api-reference/events/usage.md): This endpoint is used for transmitting usage measurement events to either a designated customer or a specific subscription.
+- [Delete a fee](https://docs.getlago.com/api-reference/fees/destroy-fee.md): This endpoint is used for deleting a specific fee that has not yet been invoiced
+- [The fee object](https://docs.getlago.com/api-reference/fees/fee-object.md): This object represents a line item of an invoice, handling amount, billed units and item description.
+- [List all fees](https://docs.getlago.com/api-reference/fees/list-fees.md): This endpoint is used for retrieving all fees that has been issued.
+- [Retrieve a fee](https://docs.getlago.com/api-reference/fees/retrieve-fee.md): This endpoint is used for retrieving a specific fee that has been issued.
+- [Update a fee](https://docs.getlago.com/api-reference/fees/update-fee.md): This endpoint is used for updating a specific fee that has been issued.
+- [Introduction](https://docs.getlago.com/api-reference/intro.md): Lago API allows your application to push customer information and metrics (events) from your application to the billing application.
+- [Create a one-off invoice](https://docs.getlago.com/api-reference/invoices/create-oneoff.md): This endpoint is used for issuing a one-off invoice.
+- [Download an invoice](https://docs.getlago.com/api-reference/invoices/download.md): This endpoint is used for downloading a specific invoice PDF document.
+- [Finalize an invoice](https://docs.getlago.com/api-reference/invoices/finalize.md): This endpoint is used for finalizing a draft invoice.
+- [List all invoices](https://docs.getlago.com/api-reference/invoices/get-all.md): This endpoint is used for retrieving all invoices.
+- [Retrieve an invoice](https://docs.getlago.com/api-reference/invoices/get-specific.md): This endpoint is used for retrieving a specific invoice that has been issued.
+- [The invoice object](https://docs.getlago.com/api-reference/invoices/invoice-object.md): This object represents an invoice generated by Lago for a specific customer. This invoice summarizes the fees generated by a subscription, usage-based charges, prepaid credit purchases, or one-off invoices.
+- [Generate a payment URL](https://docs.getlago.com/api-reference/invoices/payment-url.md): This endpoint generates a checkout link for a specific invoice.
+- [Preview an invoice](https://docs.getlago.com/api-reference/invoices/preview.md): This endpoint is used for generating invoice preview.
+- [Refresh an invoice](https://docs.getlago.com/api-reference/invoices/refresh.md): This endpoint is used for refreshing a draft invoice.
+- [Retry an invoice payment](https://docs.getlago.com/api-reference/invoices/retry.md): This endpoint resends an invoice for collection and retry a payment.
+- [Retry an invoice finalization](https://docs.getlago.com/api-reference/invoices/retry_finalization.md): This endpoint is used for retrying to generate a failed invoice.
+- [Update an invoice](https://docs.getlago.com/api-reference/invoices/update.md): This endpoint is used for updating an existing invoice.
+- [Void an invoice](https://docs.getlago.com/api-reference/invoices/void.md): This endpoint is used for voiding an invoice. • When no body parameters are provided, the invoice can be voided only if it is in a `finalized` status and its payment status is NOT `succeeded`. • When `generate_credit_note` is provided (optionally with `refund_amount` and/or `credit_amount`), this va…
+- [The organization object](https://docs.getlago.com/api-reference/organizations/organization-object.md): This object represents your organization. You can define all invoicing details and settings within it.
+- [Update organization (deprecated)](https://docs.getlago.com/api-reference/organizations/update.md): This endpoint is used to update your own organization's settings.
+- [Pagination](https://docs.getlago.com/api-reference/pagination.md)
+- [Delete a payment method from a customer](https://docs.getlago.com/api-reference/payment-methods/delete.md): This endpoint deletes a specific payment method for a customer.
+- [List all payment methods for a customer](https://docs.getlago.com/api-reference/payment-methods/get-all.md): This endpoint retrieves all payment methods of a Customer.
+- [The payment method object](https://docs.getlago.com/api-reference/payment-methods/payment-method-object.md): This object represents a payment method stored on a customer
+- [Update a payment method](https://docs.getlago.com/api-reference/payment-methods/update.md): Use the payment method as default when not selected a payment method
+- [List all payment receipts](https://docs.getlago.com/api-reference/payment-receipts/get-all.md): This endpoint is used to list all existing payment receipts.
+- [Retrieve a payment receipt](https://docs.getlago.com/api-reference/payment-receipts/get-specific.md): This endpoint retrieves a specific payment receipt.
+- [The payment receipt object](https://docs.getlago.com/api-reference/payment-receipts/payment-receipt-object.md): This object represents a receipt generated by Lago for the payment of one or multiple invoices.
+- [Create a payment request](https://docs.getlago.com/api-reference/payment-requests/create.md): This endpoint is used to create a payment request to collect payments of overdue invoices of a given customer
+- [List all payment requests](https://docs.getlago.com/api-reference/payment-requests/get-all.md): This endpoint is used to list all existing payment requests.
+- [The payment request object](https://docs.getlago.com/api-reference/payment-requests/payment-request-object.md): This object represents payment request of a group of overdue invoices for which a payment intent can be created, to settle the overdue balance.
+- [Create a payment](https://docs.getlago.com/api-reference/payments/create.md): This endpoint is used to create a manual payment
+- [List all payments](https://docs.getlago.com/api-reference/payments/get-all.md): This endpoint is used to list all payments
+- [Retrieve a payment](https://docs.getlago.com/api-reference/payments/get-specific.md): This endpoint retrieves a specific payment by its ID.
+- [The payment object](https://docs.getlago.com/api-reference/payments/payment-object.md): This object represents a payment generated by Lago for one or multiple invoices.
+- [Create a charge](https://docs.getlago.com/api-reference/plans/charges/create.md): This endpoint creates a new charge for a specific plan.
+- [Delete a charge](https://docs.getlago.com/api-reference/plans/charges/destroy.md): This endpoint deletes a specific charge from a plan.
+- [Create a charge filter](https://docs.getlago.com/api-reference/plans/charges/filters/create.md): This endpoint creates a new filter for a specific charge.
+- [Delete a charge filter](https://docs.getlago.com/api-reference/plans/charges/filters/destroy.md): This endpoint deletes a specific filter from a charge.
+- [List all charge filters](https://docs.getlago.com/api-reference/plans/charges/filters/get-all.md): This endpoint retrieves all filters for a specific charge.
+- [Retrieve a charge filter](https://docs.getlago.com/api-reference/plans/charges/filters/get-specific.md): This endpoint retrieves a specific filter for a charge.
+- [The charge filter object](https://docs.getlago.com/api-reference/plans/charges/filters/object.md): This object represents a charge filter. Filters allow differentiated pricing to be applied based on additional event properties.
+- [Update a charge filter](https://docs.getlago.com/api-reference/plans/charges/filters/update.md): This endpoint updates a specific filter for a charge.
+- [List all charges](https://docs.getlago.com/api-reference/plans/charges/get-all.md): This endpoint retrieves all charges for a specific plan.
+- [Retrieve a charge](https://docs.getlago.com/api-reference/plans/charges/get-specific.md): This endpoint retrieves a specific charge for a plan.
+- [The charge object](https://docs.getlago.com/api-reference/plans/charges/object.md): This object represents a charge associated with a plan. Charges define the pricing for usage-based billable metrics.
+- [Update a charge](https://docs.getlago.com/api-reference/plans/charges/update.md): This endpoint updates a specific charge for a plan.
+- [Create a plan](https://docs.getlago.com/api-reference/plans/create.md): This endpoint creates a plan with subscription and usage-based charges. It supports flexible billing cadence (in-advance or in-arrears) and allows for both recurring and metered charges.
+- [Delete a plan](https://docs.getlago.com/api-reference/plans/destroy.md): This endpoint deletes a specific plan. Note that this plan could be associated with active subscriptions.
+- [Create a fixed charge](https://docs.getlago.com/api-reference/plans/fixed-charges/create.md): This endpoint creates a new fixed charge for a specific plan.
+- [Delete a fixed charge](https://docs.getlago.com/api-reference/plans/fixed-charges/destroy.md): This endpoint deletes a specific fixed charge from a plan.
+- [List all fixed charges](https://docs.getlago.com/api-reference/plans/fixed-charges/get-all.md): This endpoint retrieves all fixed charges for a specific plan.
+- [Retrieve a fixed charge](https://docs.getlago.com/api-reference/plans/fixed-charges/get-specific.md): This endpoint retrieves a specific fixed charge for a plan.
+- [The fixed charge object](https://docs.getlago.com/api-reference/plans/fixed-charges/object.md): This object represents a fixed charge associated with a plan. Fixed charges are based on add-ons and support standard, graduated, and volume charge models.
+- [Update a fixed charge](https://docs.getlago.com/api-reference/plans/fixed-charges/update.md): This endpoint updates a specific fixed charge for a plan.
+- [List all plans](https://docs.getlago.com/api-reference/plans/get-all-plans.md): This endpoint retrieves all existing plans.
+- [Retrieve a plan](https://docs.getlago.com/api-reference/plans/get-specific.md): This endpoint retrieves a specific plan.
+- [The plan object](https://docs.getlago.com/api-reference/plans/object.md): This object represents a plan. This plan can then be assigned to a customer.
+- [Update a plan](https://docs.getlago.com/api-reference/plans/update.md): This endpoint updates a specific plan with subscription and usage-based charges. It supports flexible billing cadence (in-advance or in-arrears) and allows for both recurring and metered charges.
+- [Currencies](https://docs.getlago.com/api-reference/resources/currencies.md): List of accepted currencies (ISO 4217).
+- [Document locales](https://docs.getlago.com/api-reference/resources/locales.md)
+- [Timezones](https://docs.getlago.com/api-reference/resources/timezones.md): List of accepted timezones (TZ database).
+- [Create a subscription](https://docs.getlago.com/api-reference/subscriptions/assign-plan.md): This endpoint assigns a plan to a customer, creating or modifying a subscription. Ideal for initial subscriptions or plan changes (upgrades/downgrades).
+- [Create a charge filter](https://docs.getlago.com/api-reference/subscriptions/charges/filters/create.md): This endpoint creates a new filter for a specific charge on a subscription.
+- [Delete a charge filter](https://docs.getlago.com/api-reference/subscriptions/charges/filters/destroy.md): This endpoint deletes a specific filter from a charge on a subscription.
+- [List all charge filters](https://docs.getlago.com/api-reference/subscriptions/charges/filters/get-all.md): This endpoint retrieves all filters for a specific charge on a subscription.
+- [Retrieve a charge filter](https://docs.getlago.com/api-reference/subscriptions/charges/filters/get-specific.md): This endpoint retrieves a specific filter for a charge on a subscription.
+- [The charge filter object](https://docs.getlago.com/api-reference/subscriptions/charges/filters/object.md): This object represents a charge filter. Filters allow differentiated pricing to be applied based on additional event properties.
+- [Update a charge filter](https://docs.getlago.com/api-reference/subscriptions/charges/filters/update.md): This endpoint updates a specific filter for a charge on a subscription.
+- [List all charges](https://docs.getlago.com/api-reference/subscriptions/charges/get-all.md): This endpoint retrieves all effective charges for a specific subscription. If the subscription has plan overrides with charge overrides, the overridden charges are returned.
+- [Retrieve a charge](https://docs.getlago.com/api-reference/subscriptions/charges/get-specific.md): This endpoint retrieves a specific effective charge for a subscription. If the subscription has a plan override with a charge override, the overridden charge is returned.
+- [The charge object](https://docs.getlago.com/api-reference/subscriptions/charges/object.md): This object represents a charge associated with a subscription. Charges define the pricing for usage-based billable metrics.
+- [Update a charge](https://docs.getlago.com/api-reference/subscriptions/charges/update.md): This endpoint creates or updates a charge override for a specific subscription. If the subscription does not have a plan override yet, one will be created automatically. The charge override allows customizing specific charge properties (invoice_display_name, min_amount_cents, properties, filters, ta…
+- [List all fixed charges](https://docs.getlago.com/api-reference/subscriptions/fixed-charges/get-all.md): This endpoint retrieves all effective fixed charges for a specific subscription. If the subscription has plan overrides with fixed charge overrides, the overridden fixed charges are returned.
+- [Retrieve a fixed charge](https://docs.getlago.com/api-reference/subscriptions/fixed-charges/get-specific.md): This endpoint retrieves a specific effective fixed charge for a subscription. If the subscription has a plan override with a fixed charge override, the overridden fixed charge is returned.
+- [The fixed charge object](https://docs.getlago.com/api-reference/subscriptions/fixed-charges/object.md): This object represents a fixed charge associated with a subscription. Fixed charges are based on add-ons and support standard, graduated, and volume charge models.
+- [Update a fixed charge](https://docs.getlago.com/api-reference/subscriptions/fixed-charges/update.md): This endpoint creates or updates a fixed charge override for a specific subscription. If the subscription does not have a plan override yet, one will be created automatically. The fixed charge override allows customizing specific fixed charge properties (invoice_display_name, units, properties, taxe…
+- [List all subscriptions](https://docs.getlago.com/api-reference/subscriptions/get-all.md): This endpoint retrieves all active subscriptions.
+- [Retrieve subscription lifetime usage](https://docs.getlago.com/api-reference/subscriptions/get-lifetime-usage.md): This endpoint allows you to retrieve the total lifetime usage of a subscription.
+- [Retrieve a subscription](https://docs.getlago.com/api-reference/subscriptions/get-specific.md): This endpoint retrieves a specific subscription.
+- [The lifetime usage object](https://docs.getlago.com/api-reference/subscriptions/lifetime-usage-object.md): This object represents the total lifetime usage of a subscription, particularly useful for progressive billing.
+- [The subscription object](https://docs.getlago.com/api-reference/subscriptions/subscription-object.md): This object represents the assignation of plan to one of the customer of your business.
+- [Terminate a subscription](https://docs.getlago.com/api-reference/subscriptions/terminate.md): This endpoint allows you to terminate a subscription.
+- [Update a subscription](https://docs.getlago.com/api-reference/subscriptions/update.md): This endpoint allows you to update a subscription.
+- [Update subscription lifetime usage](https://docs.getlago.com/api-reference/subscriptions/update-lifetime-usage.md): This endpoint allows you to update the total lifetime usage of a subscription for migration purposes.
+- [Create a tax rate](https://docs.getlago.com/api-reference/taxes/create.md): This endpoint creates a new tax representing a customizable tax rate applicable to either the organization or a specific customer.
+- [Delete a tax rate](https://docs.getlago.com/api-reference/taxes/destroy.md): This endpoint is used to delete a tax.
+- [List all tax rates](https://docs.getlago.com/api-reference/taxes/get-all.md): This endpoint retrieves all existing taxes representing a customizable tax rate applicable to either the organization or a specific customer.
+- [Retrieve a tax rate](https://docs.getlago.com/api-reference/taxes/get-specific.md): This endpoint retrieves an existing tax representing a customizable tax rate applicable to either the organization or a specific customer. The tax is identified by its unique code.
+- [The tax object](https://docs.getlago.com/api-reference/taxes/tax-object.md): This object represents a customizable tax rate applicable to either the organization or a specific customer.
+- [Update a tax rate](https://docs.getlago.com/api-reference/taxes/update.md): This endpoint updates an existing tax representing a customizable tax rate applicable to either the organization or a specific customer.
+- [Create a wallet](https://docs.getlago.com/api-reference/wallets/create.md): This endpoint is used to create a wallet with prepaid credits.
+- [Create a wallet alert](https://docs.getlago.com/api-reference/wallets/create-alert.md): This endpoint allows you to create a new alert for a wallet.
+- [Delete a wallet alert](https://docs.getlago.com/api-reference/wallets/delete-alert.md): This endpoint allows you to delete an existing alert for a wallet.
+- [List all wallets](https://docs.getlago.com/api-reference/wallets/get-all.md): This endpoint is used to list all wallets with prepaid credits.
+- [List all wallet alerts](https://docs.getlago.com/api-reference/wallets/get-all-alerts.md): This endpoint allows you to retrieve all alerts for a wallet.
+- [List all consumptions for a wallet transaction](https://docs.getlago.com/api-reference/wallets/get-all-consumptions.md): This endpoint is used to list all consumption records for an inbound wallet transaction. It shows how the credits from this inbound transaction were consumed by outbound transactions. Only available for traceable wallets.
+- [List all fundings for a wallet transaction](https://docs.getlago.com/api-reference/wallets/get-all-fundings.md): This endpoint is used to list all funding records for an outbound wallet transaction. It shows which inbound transactions funded this outbound transaction. Only available for traceable wallets.
+- [List all wallet transactions](https://docs.getlago.com/api-reference/wallets/get-all-transactions.md): This endpoint is used to list all wallet transactions.
+- [Retrieve a wallet](https://docs.getlago.com/api-reference/wallets/get-specific.md): This endpoint is used to retrieve an existing wallet with prepaid credits.
+- [Retrieve a wallet alert](https://docs.getlago.com/api-reference/wallets/get-specific-alert.md): This endpoint allows you to retrieve a specific alert for a wallet.
+- [Retrieve a transaction](https://docs.getlago.com/api-reference/wallets/get-specific-transaction.md): This endpoint is used to retrieve a specific wallet transactions.
+- [Terminate a wallet](https://docs.getlago.com/api-reference/wallets/terminate.md): This endpoint is used to terminate an existing wallet with prepaid credits.
+- [Top-up a wallet](https://docs.getlago.com/api-reference/wallets/top-up.md): This endpoint is used to top-up an active wallet.
+- [Update a wallet](https://docs.getlago.com/api-reference/wallets/update.md): This endpoint is used to update an existing wallet with prepaid credits.
+- [Update a wallet alert](https://docs.getlago.com/api-reference/wallets/update-alert.md): This endpoint allows you to update an existing alert for a wallet.
+- [The wallet alert object](https://docs.getlago.com/api-reference/wallets/wallet-alert-object.md): This object represents an alert to monitor your wallets' credits consumption by firing notifications when certain conditions are met.
+- [The wallet object](https://docs.getlago.com/api-reference/wallets/wallet-object.md): This object represents a wallet, holding free or prepaid credits.
+- [The wallet transaction object](https://docs.getlago.com/api-reference/wallets/wallet-transaction-object.md): This object represents a wallet transaction. It is used for topping up or voiding prepaid credits.
+- [Generate a payment URL](https://docs.getlago.com/api-reference/wallets/wallet-transaction-payment-url.md): This endpoint generates a checkout link for a specific wallet transaction.
+- [Create a webhook endpoint](https://docs.getlago.com/api-reference/webhook-endpoints/create.md): This endpoint is used to create a webhook endpoint.
+- [Delete a webhook endpoint](https://docs.getlago.com/api-reference/webhook-endpoints/destroy.md)
+- [List all webhook endpoints](https://docs.getlago.com/api-reference/webhook-endpoints/get-all.md): This endpoint is used to list all webhook endpoints.
+- [Retrieve a webhook endpoint](https://docs.getlago.com/api-reference/webhook-endpoints/get-specific.md): This endpoint is used to retrieve an existing webhook endpoint.
+- [Update a webhook endpoint](https://docs.getlago.com/api-reference/webhook-endpoints/update.md): This endpoint is used to update an existing webhook endpoint.
+- [The webhook endpoint object](https://docs.getlago.com/api-reference/webhook-endpoints/webhook-endpoint-object.md): This object represents the webhook endpoint used for listening to Lago’s events
+- [Format & Signature](https://docs.getlago.com/api-reference/webhooks/format---signature.md): Webhooks are HTTP notifications sent from Lago to your application.
+- [Messages](https://docs.getlago.com/api-reference/webhooks/messages.md): Below is a list of the event types we currently send. Please note that additional event types may be introduced in the future, so your code should be flexible enough to accommodate new types as they arise. Our objective is to maintain a consistent and predictable event structure, making it easier to…
+- [Product updates](https://docs.getlago.com/changelog/product.md): New updates and improvements to Lago.
+- [About Lago](https://docs.getlago.com/faq/about-lago.md)
+- [About the software](https://docs.getlago.com/faq/about-software.md)
+- [Community](https://docs.getlago.com/faq/community.md)
+- [Deployment](https://docs.getlago.com/faq/deployment.md)
+- [General](https://docs.getlago.com/faq/general.md)
+- [Pricing](https://docs.getlago.com/faq/pricing.md)
+- [Product features](https://docs.getlago.com/faq/product-features.md)
+- [The Billing Assistant (Beta)](https://docs.getlago.com/guide/ai-agents/billing-assistant.md): Your AI-powered billing assistant for automating manual and repetitive billing operations.
+- [Lago MCP Server](https://docs.getlago.com/guide/ai-agents/mcp-server.md): Connect Lago live data, models, and billing logic to any AI system, bringing billing context and interactions everywhere.
+- [Credits consumption alerts](https://docs.getlago.com/guide/alerts/credits-consumption-alerts.md): Credits consumption alerts allow you to monitor your customers' wallet balances by firing notifications when certain thresholds are crossed.
+- [Usage alerts](https://docs.getlago.com/guide/alerts/usage-alerts.md): Usage alerts allow you to monitor your subscriptions' usage and billing by firing notifications when certain conditions are met.
+- [Forecasted usage](https://docs.getlago.com/guide/analytics/forecasted-usage.md)
+- [Reports](https://docs.getlago.com/guide/analytics/reports.md): Lago provides a unified analytics layer for billing, revenue, and product usage data. It enables finance and operations teams to compute, monitor, and reconcile revenue metrics with accuracy and confidence.
+- [Aggregation examples](https://docs.getlago.com/guide/billable-metrics/aggregation-types/aggregation-examples.md)
+- [COUNT](https://docs.getlago.com/guide/billable-metrics/aggregation-types/count.md)
+- [UNIQUE COUNT](https://docs.getlago.com/guide/billable-metrics/aggregation-types/count-unique.md)
+- [CUSTOM](https://docs.getlago.com/guide/billable-metrics/aggregation-types/custom-agg.md)
+- [LATEST](https://docs.getlago.com/guide/billable-metrics/aggregation-types/latest.md)
+- [MAX](https://docs.getlago.com/guide/billable-metrics/aggregation-types/max.md)
+- [Overview](https://docs.getlago.com/guide/billable-metrics/aggregation-types/overview.md): Aggregation types will define how consumption will be measured.
+- [SUM](https://docs.getlago.com/guide/billable-metrics/aggregation-types/sum.md)
+- [WEIGHTED SUM](https://docs.getlago.com/guide/billable-metrics/aggregation-types/weighted-sum.md)
+- [Create billable metrics](https://docs.getlago.com/guide/billable-metrics/create-billable-metrics.md): Billable metrics define how incoming events are aggregated in order to measure consumption.
+- [Delete billable metrics](https://docs.getlago.com/guide/billable-metrics/delete-billable-metrics.md)
+- [Filters](https://docs.getlago.com/guide/billable-metrics/filters.md): When setting up your pricing, you may want to filters events according to their property. To do so, you can create filters for your billable metric.
+- [Recurring vs metered](https://docs.getlago.com/guide/billable-metrics/recurring-vs-metered.md)
+- [Rounding](https://docs.getlago.com/guide/billable-metrics/rounding.md): Lago aggregates your events in real time. You can add rounding rules to the final result.
+- [SQL Expressions](https://docs.getlago.com/guide/billable-metrics/sql-expressions.md): For more advanced calculations, you can use SQL custom expressions. These expressions are helpful when the aggregation results for a billable metric require complex calculations.
+- [Billing entities](https://docs.getlago.com/guide/billing-entities.md): Billing entities allow an organization to manage different billing configurations.
+- [Coupons](https://docs.getlago.com/guide/coupons.md): Coupons allow you to offer discounts to your customers. When you apply a coupon to a customer,  its value will be deducted from their next subscription invoice(s).
+- [Customer management](https://docs.getlago.com/guide/customers/customer-management.md)
+- [Customer metadata](https://docs.getlago.com/guide/customers/customer-metadata.md)
+- [The customer portal](https://docs.getlago.com/guide/customers/customer-portal.md)
+- [Invoice a customer](https://docs.getlago.com/guide/customers/invoice-customer.md)
+- [Automatic dunning](https://docs.getlago.com/guide/dunning/automatic-dunning.md): Automate customer communications to remind them of overdue invoices and recover outstanding balances through targeted dunning campaigns.
+- [Manual dunning](https://docs.getlago.com/guide/dunning/manual-dunning.md): Dunning refers to the process of communicating with customers to remind them of overdue invoices and attempt to recover the outstanding amounts.
+- [Emails](https://docs.getlago.com/guide/emails.md): Send automatic emails when issuing an invoice or any billing documents.
+- [Entitlements](https://docs.getlago.com/guide/entitlements.md): Unify entitlements and billing in one streamlined platform with Lago.
+- [Ingest usage](https://docs.getlago.com/guide/events/ingesting-usage.md): Design, send, and manage usage events that Lago turns into accurate, auditable invoices.
+- [Metering ingestion sources](https://docs.getlago.com/guide/events/metering-source.md): Here is a list of sources you can use to ingest usage data. Some of these sources are capable of handling up to 15,000 events per second with default settings.
+- [Retrieve usage](https://docs.getlago.com/guide/events/retrieve-usage.md): Monitor ingested events, debug warnings, and retrieve current, projected, or past usage data for your customers.
+- [Performance & Optimization](https://docs.getlago.com/guide/events/usage-performances.md): Lago's event processing architecture, production benchmarks, throughput by connector, and optimization strategies for engineering teams.
+- [Integration testing](https://docs.getlago.com/guide/integration-testing.md): This step-by-step integration guide will help you get started with Lago.
+- [Welcome to Lago](https://docs.getlago.com/guide/introduction/welcome-to-lago.md): Lago is an open-source software for metering and usage-based billing. It's the best alternative to Chargebee, Recurly or Stripe Billing for companies that need to handle complex billing logic.
+- [Why billing is a nightmare](https://docs.getlago.com/guide/introduction/why-billing-is-a-nightmare.md)
+- [Credit note metadata](https://docs.getlago.com/guide/invoicing/credit-notes/credit-note-metadata.md)
+- [Overview](https://docs.getlago.com/guide/invoicing/credit-notes/overview.md)
+- [Download invoices](https://docs.getlago.com/guide/invoicing/download-invoices.md)
+- [Draft invoices](https://docs.getlago.com/guide/invoicing/draft-invoices.md): A draft invoice is an editable invoice by several ways.
+- [E-Invoicing contributions](https://docs.getlago.com/guide/invoicing/e-invoicing/contributions.md): Learn how to contribute new E-Invoicing formats and jurisdictions to Lago
+- [Overview](https://docs.getlago.com/guide/invoicing/e-invoicing/overview.md): Lago automatically generates e-invoices for your billing entities and customers that comply with local regulations
+- [Export invoices](https://docs.getlago.com/guide/invoicing/export.md): Lago enables you to filter invoices and export them as a simple or advanced CSV file, tailored to your needs.
+- [Fees](https://docs.getlago.com/guide/invoicing/fees.md): A fee is a line item in an invoice.
+- [Invoice metadata](https://docs.getlago.com/guide/invoicing/invoice-metadata.md)
+- [Empty invoice generation](https://docs.getlago.com/guide/invoicing/invoicing-settings/empty-invoices.md): Configure whether Lago should generate invoices with a total amount of zero.
+- [Grace period](https://docs.getlago.com/guide/invoicing/invoicing-settings/grace-period.md): Configure a buffer between invoice generation and finalization to review invoices.
+- [Invoice numbering](https://docs.getlago.com/guide/invoicing/invoicing-settings/invoice-numbering.md): Define how invoice numbers are generated — per customer or across the billing entity.
+- [Issuing date preferences](https://docs.getlago.com/guide/invoicing/invoicing-settings/issuing_date.md): Control when your subscription invoices are dated.
+- [Net payment term](https://docs.getlago.com/guide/invoicing/invoicing-settings/net-payment-term.md): Number of days a customer has to pay an invoice after it has been finalized
+- [Overview](https://docs.getlago.com/guide/invoicing/invoicing-settings/overview.md): Define invoice look and feel per entity to match your requierement.
+- [Taxes](https://docs.getlago.com/guide/invoicing/invoicing-settings/taxes.md): When generating invoices, you may need to apply VAT or other taxes. By creating tax objects and applying them to billing entities and/or customers, the corresponding invoices will reflect the appropriate tax rates.
+- [Overview](https://docs.getlago.com/guide/invoicing/overview.md): Lago automatically generates invoices for each customer according to the plan model.
+- [Preview an invoice](https://docs.getlago.com/guide/invoicing/previews.md): With Lago, you can preview invoices even if the customer doesn't exist yet, for pending subscriptions, or for active subscriptions.
+- [Void invoices](https://docs.getlago.com/guide/invoicing/void.md)
+- [Lago Cloud](https://docs.getlago.com/guide/lago-cloud.md): Lago Cloud is the fully hosted version of our open-source billing API.
+- [Lago OpenAPI](https://docs.getlago.com/guide/lago-open-api.md)
+- [Useful commands](https://docs.getlago.com/guide/lago-self-hosted/commands.md): Useful commands for self-hosted users.
+- [Compatibility Matrix](https://docs.getlago.com/guide/lago-self-hosted/compatibility-matrix.md): Supported technologies and versions for Lago self-hosted deployments.
+- [Database maintenance](https://docs.getlago.com/guide/lago-self-hosted/database-maintenance.md): Keeping your Postgres at its best
+- [Docker](https://docs.getlago.com/guide/lago-self-hosted/docker.md): Docker is the easiest way to get started with the self-hosted version of Lago.
+- [Overview](https://docs.getlago.com/guide/lago-self-hosted/overview.md): Deploy Lago seamlessly on your infrastructure, compatible with both free and premium editions.
+- [Tracking & Analytics](https://docs.getlago.com/guide/lago-self-hosted/tracking-analytics.md)
+- [Versions update](https://docs.getlago.com/guide/lago-self-hosted/update-instance.md)
+- [Migration to v1.2.0](https://docs.getlago.com/guide/migration/migration-to-v1.2.0.md)
+- [Migration to v1.20.0](https://docs.getlago.com/guide/migration/migration-to-v1.20.0.md)
+- [Migration to v1.25.0](https://docs.getlago.com/guide/migration/migration-to-v1.25.0.md)
+- [Migration to v1.28.1](https://docs.getlago.com/guide/migration/migration-to-v1.28.1.md)
+- [Migration to v1.29.0](https://docs.getlago.com/guide/migration/migration-to-v1.29.0.md)
+- [Migration to v1.31.0](https://docs.getlago.com/guide/migration/migration-to-v1.31.0.md)
+- [Migration to v1.32.0](https://docs.getlago.com/guide/migration/migration-to-v1.32.0.md)
+- [Migration to v1.43.0](https://docs.getlago.com/guide/migration/migration-to-v1.43.0.md)
+- [Migration to v1.44.0](https://docs.getlago.com/guide/migration/migration-to-v1.44.0.md)
+- [Migration to v1.45.0](https://docs.getlago.com/guide/migration/migration-to-v1.45.0.md)
+- [Create add-ons](https://docs.getlago.com/guide/one-off-invoices/create-add-ons.md): Add-ons let you apply one-time fixed fees to plans or one-off invoices. They are commonly used for setup fees, one-off charges, or customer success fees.
+- [Issue one-off invoices](https://docs.getlago.com/guide/one-off-invoices/create-one-off-invoices.md): One-off invoices allow you to bill immediately one or several add-ons to a customer.  This guide will show you how to create a one-off invoice for a specific customer using the add-ons.
+- [Payment pre-authorization](https://docs.getlago.com/guide/payments/payment-authorization.md): Learn how to validate payment methods before creating, upgrading, or downgrading customer subscriptions.
+- [Payment methods (Beta)](https://docs.getlago.com/guide/payments/payment-methods.md): Customer’s payment instrument (card, bank account, direct debit mandate, etc.), managed by an external Payment Service Provider (PSP).
+- [Payment providers integrations](https://docs.getlago.com/guide/payments/payment-providers.md): Automatically collect payments from Payment Providers by using native integrations or webhook messages.
+- [Payment retries](https://docs.getlago.com/guide/payments/payment-retries.md)
+- [Payment receipts](https://docs.getlago.com/guide/payments/receipts.md): Lago automatically generates payment receipts for each payment processed, whether manual or through payment provider integrations.
+- [Record manual payments](https://docs.getlago.com/guide/payments/record-manual-payments.md): On top of our native integrations with leading payment providers, you can also record manual payments.
+- [Arrears vs Advance](https://docs.getlago.com/guide/plans/charges/arrears-vs-advance.md): Usage-based charges can be either charged in advance or in arrears
+- [Custom price](https://docs.getlago.com/guide/plans/charges/charge-models/custom-price.md)
+- [Dynamic](https://docs.getlago.com/guide/plans/charges/charge-models/dynamic.md)
+- [Graduated](https://docs.getlago.com/guide/plans/charges/charge-models/graduated.md)
+- [Graduated percentage](https://docs.getlago.com/guide/plans/charges/charge-models/graduated-percentage.md)
+- [Package](https://docs.getlago.com/guide/plans/charges/charge-models/package.md)
+- [Percentage](https://docs.getlago.com/guide/plans/charges/charge-models/percentage.md)
+- [Standard](https://docs.getlago.com/guide/plans/charges/charge-models/standard.md)
+- [Volume](https://docs.getlago.com/guide/plans/charges/charge-models/volume.md)
+- [Charges with filters](https://docs.getlago.com/guide/plans/charges/charges-with-filters.md): Charge your customers by leveraging a combination of filters specified in the billable metric.
+- [Fixed charge](https://docs.getlago.com/guide/plans/charges/fixed-charges.md): Fixed charges are recurring fees tied to add-ons. They are billed independently of usage events and applied as a fixed amount on invoices.
+- [Group keys](https://docs.getlago.com/guide/plans/charges/grouping.md)
+- [Invoiceable vs Uninvoiceable](https://docs.getlago.com/guide/plans/charges/invoiceable-vs-noninvoiceable.md): In-advance charges can be either invoiceable or not.
+- [Metered vs Recurring](https://docs.getlago.com/guide/plans/charges/metered-vs-recurring.md): Usage-based charges can be either metered or recurring
+- [Prorated vs Full](https://docs.getlago.com/guide/plans/charges/prorated-vs-full.md): Usage-based charges can be either billed fully or prorated based on the number of days used.
+- [Spending minimums](https://docs.getlago.com/guide/plans/charges/spending-minimum.md)
+- [Usage based charge](https://docs.getlago.com/guide/plans/charges/usage-based-charges.md): Usage-based charges let you bill customers based on actual consumption. They are tied to billable metrics and calculated from usage events collected during the billing period.
+- [Commitments](https://docs.getlago.com/guide/plans/commitment.md)
+- [Custom pricing units](https://docs.getlago.com/guide/plans/custom-pricing-units.md): A pricing unit works like a custom currency, allowing you to express charges in something other than fiat (e.g., credits or tokens).
+- [Overview](https://docs.getlago.com/guide/plans/overview.md): If Billable metrics are made to measure customer usage, Plans are made to apply prices to this usage.
+- [Plan model](https://docs.getlago.com/guide/plans/plan-model.md): The plan model defines when and how much a customer is charged.
+- [Progressive billing](https://docs.getlago.com/guide/plans/progressive-billing.md): Progressive billing, also known as threshold billing, automatically triggers an invoice when a customer's cumulative usage reaches predefined thresholds. This method ensures that customers cannot exceed certain usage limits without ensuring payment is received, reducing the risk of unpaid services o…
+- [Revenue share](https://docs.getlago.com/guide/revenue-share.md): Model your revenue-sharing structure within Lago.
+- [API Keys](https://docs.getlago.com/guide/security/api-keys.md)
+- [Audit logs](https://docs.getlago.com/guide/security/audit-logs.md): The audit logs enable organization admins to efficiently track member activity, providing detailed records of who performed each action, what was done, and when it occurred.
+- [RBAC - Role-Based Access Control](https://docs.getlago.com/guide/security/rbac.md): Define user roles & permissions in Lago.
+- [Security logs](https://docs.getlago.com/guide/security/security-logs.md): Security logs track critical actions related to team management, authentication, API keys, and other security-sensitive operations within your organization.
+- [SOC 2 Type 2](https://docs.getlago.com/guide/security/soc.md): Keeping your data secure.
+- [Single Sign-On (SSO)](https://docs.getlago.com/guide/security/sso.md)
+- [Assign a plan to a customer](https://docs.getlago.com/guide/subscriptions/assign-plan.md): A subscription is created when a plan is assigned to a customer.  You can assign a plan to a customer at any time (i.e. when the customer record is created or later on).
+- [Edit a subscription](https://docs.getlago.com/guide/subscriptions/edit-subscription.md): You can edit a subscription at any time, whether it's active or pending.
+- [Terminate a subscription](https://docs.getlago.com/guide/subscriptions/terminate-subscription.md): You can terminate a subscription at any time, whether it's active or pending.
+- [Upgrades and downgrades](https://docs.getlago.com/guide/subscriptions/upgrades-downgrades.md): Customers have the flexibility to easily upgrade or downgrade their plan at any given moment.
+- [Overview](https://docs.getlago.com/guide/wallet-and-prepaid-credits/overview.md): Since usage-based charges can be calculated at the end of the billing period, you often need to wait to collect payments. With prepaid credits, you can now unlock recurring revenue opportunities for pay-as-you-go pricing models.
+- [Traceability](https://docs.getlago.com/guide/wallet-and-prepaid-credits/traceability.md): Track how credits flow between inbound and outbound wallet transactions.
+- [Top-up and void credits](https://docs.getlago.com/guide/wallet-and-prepaid-credits/wallet-top-up-and-void.md): Add and void credits, to the customer's wallet.
+- [Webhooks](https://docs.getlago.com/guide/webhooks.md)
+- [NetSuite](https://docs.getlago.com/integrations/accounting/netsuite.md): Lago seamlessly integrates with NetSuite, enabling real-time synchronization of billing data with your preferred accounting tool.
+- [QuickBooks](https://docs.getlago.com/integrations/accounting/quickbooks.md): Sync Lago billing data to QuickBooks Online via n8n.
+- [Xero](https://docs.getlago.com/integrations/accounting/xero.md): Lago seamlessly integrates with Xero, enabling real-time synchronization of billing data with your preferred accounting tool.
+- [N8N](https://docs.getlago.com/integrations/alerting/n8n.md)
+- [Zapier](https://docs.getlago.com/integrations/alerting/zapier.md)
+- [HubSpot](https://docs.getlago.com/integrations/crm/hubspot.md): Lago syncs billing data to HubSpot in real-time.
+- [Salesforce CPQ](https://docs.getlago.com/integrations/crm/salesforce-cpq.md): Lago syncs billing data to Salesforce in real-time.
+- [Salesforce CRM](https://docs.getlago.com/integrations/crm/salesforce-crm.md): Lago syncs billing data to Salesforce in real-time.
+- [Airbyte (ETL)](https://docs.getlago.com/integrations/data/airbyte.md)
+- [Lago Data Pipeline](https://docs.getlago.com/integrations/data/lago-data-pipeline.md): Sync your Lago data with your data warehouse or cloud storage
+- [Oso](https://docs.getlago.com/integrations/entitlements/osohq.md)
+- [Introduction](https://docs.getlago.com/integrations/introduction.md): Find all Lago integrations with third-party tools—whether for payment providers, alerting systems, or data integrations. Note that some integrations are native and actively maintained by Lago, while others are community-developed and come with limited support.
+- [AWS Marketplace](https://docs.getlago.com/integrations/marketplaces/aws-marketplace.md): Lago integrates with AWS marketplace through our partner Suger.io
+- [Azure Marketplace](https://docs.getlago.com/integrations/marketplaces/azure-marketplace.md): Lago integrates with Azure marketplace through our partner Suger.io
+- [GCP Marketplace](https://docs.getlago.com/integrations/marketplaces/gcp-marketplace.md): Lago integrates with GCP marketplace through our partner Suger.io
+- [Adyen](https://docs.getlago.com/integrations/payments/adyen-integration.md): Lago's native integration with Adyen allows you to collect payments automatically when new invoices are generated.
+- [Cashfree Payments](https://docs.getlago.com/integrations/payments/cashfree-integration.md): Make your users pay Lago invoices with Cashfree Payments, India's leading payments and API banking company.
+- [GoCardless](https://docs.getlago.com/integrations/payments/gocardless-integration.md): Lago's native integration with GoCardless allows you to collect payments via direct debit.
+- [Moneyhash](https://docs.getlago.com/integrations/payments/moneyhash-integration.md): Moneyhash is a leading payment infrastructure software in Africa and the Middle East.
+- [Stripe](https://docs.getlago.com/integrations/payments/stripe-integration.md): Lago's native integration with Stripe allows you to collect payments automatically when new invoices are generated.
+- [Anrok](https://docs.getlago.com/integrations/taxes/anrok.md): Lago's native integration with Anrok allows you to automatically update your invoices with tax amounts sourced directly from Anrok. This integration ensures compliance with international tax regulations by calculating taxes for US & non-US obligations, like VAT.
+- [Avalara](https://docs.getlago.com/integrations/taxes/avalara.md): Lago's native integration with Avalara allows you to automatically update your invoices with tax amounts sourced directly from Avalara. This integration ensures compliance with international tax regulations by calculating taxes for US & non-US obligations, like VAT.
+- [Lago EU Taxes](https://docs.getlago.com/integrations/taxes/lago-eu-taxes.md)
+- [Hightouch](https://docs.getlago.com/integrations/usage/hightouch.md): Hightouch is a Data Activation platform that syncs data from sources (database, warehouses, spreadsheet and much more) to business  applications and developer tools. This data can be sent to Lago, our usage-based billing platform, to automate your billing process  and ensure accurate invoicing for y…
+- [Segment](https://docs.getlago.com/integrations/usage/segment.md): Segment is a powerful tool that allows you to track the usage of your customers, providing valuable insights that can help you make  data-driven decisions. This data can be sent to Lago, our usage-based billing platform, to automate your billing process and ensure  accurate invoicing for your custom…
+- [Clone Segment pricing](https://docs.getlago.com/templates/hybrid/segment.md): Replicate Segment's hybrid pricing model with Lago.
+- [Introduction](https://docs.getlago.com/templates/introduction.md): Replicate these popular B2B pricing templates to kickstart your journey with Lago.
+- [Clone Algolia pricing](https://docs.getlago.com/templates/payg/algolia.md): Replicate Algolia's pay-as-you-go pricing model with Lago.
+- [Clone Google BigQuery pricing](https://docs.getlago.com/templates/payg/bigquery.md): Replicate BigQuery's pay-as-you-go pricing model and offer free upfront credits with Lago.
+- [Clone Notion pricing](https://docs.getlago.com/templates/per-seat/notion.md): Replicate Notion's per-seat pricing model with Lago.
+- [Clone Mistral pricing](https://docs.getlago.com/templates/per-token/mistral.md): Replicate Mistral's per-token pricing model with Lago.
+- [Clone OpenAI pricing](https://docs.getlago.com/templates/per-token/openai.md): Replicate OpenAI's per-token pricing model with Lago.
+- [Clone Stripe pricing](https://docs.getlago.com/templates/per-transaction/stripe.md): Replicate Stripe's per-transaction pricing model with Lago.
+- [Welcome](https://docs.getlago.com/welcome.md)
+
+## OpenAPI Specs
+
+- [openapi](https://swagger.getlago.com/openapi.yaml)
+
+## Optional
+
+- [Blog](https://www.getlago.com/blog)
+- [Community](https://www.getlago.com/slack)
+- [GitHub](https://github.com/getlago/lago)
+- [Status](https://status.getlago.com/)


### PR DESCRIPTION
## Summary
- Adds a custom `llms.txt` that overrides Mintlify's auto-generated version
- Prepends an **Instructions section** (inspired by [Stripe's pattern](https://docs.stripe.com/llms.txt)) that tells AI coding assistants the correct Lago integration flow
- Covers: auth, the billable metric → plan → customer → subscription → events sequence, idempotency, batch events, payment providers, wallets, webhooks, and pricing models

## Why
AI coding assistants (Cursor, Copilot, Claude) are becoming the primary way developers discover and integrate billing APIs. Without behavioral guidance in `llms.txt`, they guess the integration order and often get it wrong — e.g., creating events before creating a billable metric.

Stripe already does this and it dramatically improves generated code quality.

## Test plan
- [ ] Verify `docs.getlago.com/llms.txt` serves the custom file (not the auto-generated one) after deploy
- [ ] Test in Cursor: "Set up usage-based billing with Lago in Python" — should follow the correct flow
- [ ] Test in Claude: "Push metering events to Lago API" — should include idempotency key

## Note
The custom file includes all existing auto-generated page links so nothing is lost. The only addition is the blockquote description + Instructions section at the top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)