### PR TITLE
docs: Document operation_type for UNIQUE COUNT events

### DIFF
--- a/guide/billable-metrics/aggregation-types/count-unique.mdx
+++ b/guide/billable-metrics/aggregation-types/count-unique.mdx
@@ -78,3 +78,23 @@ Lago calculates the `COUNT_DISTINCT(events.properties.property_name)` for the tw
 ```
 
 In that case, with this aggregation type, Lago only counts the unique values of the `request_id` property in the event payloads, **resulting in a billable value of 1 unit.**
+
+## Adding or removing unique values
+Events sent to a `UNIQUE COUNT` billable metric accept an `operation_type` property to control whether the unique value is added to or removed from the count:
+
+- `add`: Adds the unique value. **Optional**: Lago adds by default if `operation_type` is omitted.
+- `remove`: Removes the unique value from the count. **Required** whenever you want to explicitly remove a unit.
+
+```json
+//Event removing a previously counted unique value
+{
+    "transaction_id": "transaction_3",
+    "external_customer_id": "1",
+    "timestamp": "2022-03-18T00:00:00Z",
+    "code": "api_requests",
+    "properties": {
+        "request_id": "id_1",
+        "operation_type": "remove"
+    }
+}
+```

--- a/guide/events/ingesting-usage.mdx
+++ b/guide/events/ingesting-usage.mdx
@@ -91,9 +91,10 @@ The guiding question: **what do you charge your customers for?** That's your eve
 
     Lago ignores properties that don't match a billable metric, so **include dimensions you might price on in the future** — extra fields cost nothing but give you pricing flexibility later.
 
-    <Info>
-      For `UNIQUE COUNT` aggregation on a `recurring` metric, the `operation_type` property is required. Send `add` to add a value or `remove` to remove one.
-    </Info>
+    Events sent to a `UNIQUE COUNT` billable metric accept an `operation_type` property to control whether the unique value is added to or removed from the count:
+    - `add`: Adds the unique value. **Optional**: Lago adds by default if `operation_type` is omitted.
+    - `remove`: Removes the unique value from the count. **Required** whenever you want to explicitly remove a unit.
+
   </Accordion>
 
   <Accordion title="precise_total_amount_cents (optional)">


### PR DESCRIPTION
## Summary
- Add a new "Adding or removing unique values" section to the `UNIQUE COUNT` aggregation page explaining the `operation_type` event property (`add` is optional/default, `remove` is required to drop a unit), with an example event payload.
- Update the `operation_type` note in the ingesting usage events guide to match the same wording and clarify when each value is required vs optional.

## Test plan
- [ ] Verify the new section renders correctly on the UNIQUE COUNT aggregation page.
- [ ] Verify the updated `operation_type` description in the ingesting usage events guide reads correctly.