### PR TITLE
docs: document Apple Pay and Google Pay support in Stripe integration

### DIFF
--- a/integrations/payments/stripe-integration.mdx
+++ b/integrations/payments/stripe-integration.mdx
@@ -176,6 +176,76 @@ The checkout URL provided by Lago is designed to handle multiple payment options
   </Accordion>
 </AccordionGroup>
 
+### Digital wallets
+Apple Pay and Google Pay are wallets surfaced by Stripe Checkout on top of the `card` payment method. They do not require a separate value in `provider_payment_methods`. Enabling `card` in Lago is sufficient. They appear automatically on the Lago-generated checkout URL and on one-off invoice payment links when the customer is on a compatible device.
+
+<AccordionGroup>
+  <Accordion title="Apple Pay" icon="apple">
+    Apple Pay is offered to customers on supported Apple devices (Safari on macOS, iOS) when `card` is included in `provider_payment_methods` and Apple Pay is activated in your Stripe Dashboard. Stripe handles domain verification and wallet display.
+
+    No additional value is needed in `provider_payment_methods`, the payload is identical to the Card payment method.
+
+    <Warning>
+      Apple Pay must be activated in your [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods). On unsupported devices, customers see the standard card form as a fallback.
+    </Warning>
+
+    ```bash
+    LAGO_URL="https://api.getlago.com"
+    API_KEY="__YOUR_API_KEY__"
+
+    curl --location --request POST "$LAGO_URL/api/v1/customers" \
+      --header "Authorization: Bearer $API_KEY" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+        "customer": {
+          "external_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "address_line1": "5230 Penfield Ave",
+          "billing_configuration": {
+            "invoice_grace_period": 3,
+            "payment_provider": "stripe",
+            "provider_customer_id": "cus_12345",
+            "sync": true,
+            "sync_with_provider": true,
+            "provider_payment_methods": ["card"]
+          }
+        }
+      }'
+    ```
+  </Accordion>
+  <Accordion title="Google Pay" icon="google">
+    Google Pay is offered to customers on supported devices (Chrome, Android) when `card` is included in `provider_payment_methods` and Google Pay is activated in your Stripe Dashboard. Stripe handles wallet display and tokenization.
+
+    No additional value is needed in `provider_payment_methods` — the payload is identical to the Card payment method.
+
+    <Warning>
+      Google Pay must be activated in your [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods). On unsupported devices, customers see the standard card form as a fallback.
+    </Warning>
+
+    ```bash
+    LAGO_URL="https://api.getlago.com"
+    API_KEY="__YOUR_API_KEY__"
+
+    curl --location --request POST "$LAGO_URL/api/v1/customers" \
+      --header "Authorization: Bearer $API_KEY" \
+      --header 'Content-Type: application/json' \
+      --data-raw '{
+        "customer": {
+          "external_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+          "address_line1": "5230 Penfield Ave",
+          "billing_configuration": {
+            "invoice_grace_period": 3,
+            "payment_provider": "stripe",
+            "provider_customer_id": "cus_12345",
+            "sync": true,
+            "sync_with_provider": true,
+            "provider_payment_methods": ["card"]
+          }
+        }
+      }'
+    ```
+  </Accordion>
+</AccordionGroup>
+
 ### Localized payment methods
 <AccordionGroup>
   <Accordion title="SEPA debits (EU only)" icon="money-bill-transfer">


### PR DESCRIPTION
## Summary

- Adds a new **Digital wallets** subsection to the Stripe integration doc, with accordions for Apple Pay and Google Pay.
- Clarifies that wallets ride on top of the `card` payment method and do **not** require a new value in `provider_payment_methods` — enabling `card` in Lago plus activating the wallet in the Stripe Dashboard is enough.
- Reuses the existing Card payload in each cURL example to make the API contract unambiguous, and links to the Stripe Dashboard payment methods settings.

## Why

Developers searching the docs for "apple pay" or "google pay" currently hit nothing and may assume Lago doesn't support them, or open a ticket. Stripe surfaces these wallets automatically on Checkout (which Lago uses for both the customer checkout URL and one-off invoice payment links) when card is enabled — we just weren't documenting that.

## Test plan

- [ ] Run \`mintlify dev\` and load the Stripe integration page
- [ ] Verify the new "Digital wallets" heading renders between "General payment methods" and "Localized payment methods"
- [ ] Expand both accordions; confirm the Warning callout and cURL block render correctly
- [ ] Confirm \`apple\` and \`google\` icons display; fall back to \`mobile-screen\` / \`wallet\` if the brand icons aren't available in Mintlify's default set
- [ ] Confirm the existing AccordionGroups above and below are unaffected