### PR TITLE
[ING-103] docs(self-hosted): Redis configuration

### DIFF
--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -295,6 +295,151 @@ For an exhaustive list of SSL parameters, refer to the [libpq documentation](htt
 - **Encrypt connections.** Configure SSL with `verify-full` against a known CA. See [Enabling SSL](#enabling-ssl) above.
 - **Keep Postgres healthy.** Once Lago is connected, follow the [Database maintenance](/guide/lago-self-hosted/database-maintenance) guide for autovacuum, autoanalyze and slow-query monitoring.
 
+### Configuring Redis[](#configuring-redis "Direct link to heading")
+
+Lago uses Redis for two independent purposes:
+
+- **Job queue** — Sidekiq stores background-job state in Redis. The API enqueues jobs that workers and the clock process pick up.
+- **Application cache** — short-lived computed values (wallet balances, etc.) that the application reads back from `Rails.cache`.
+
+You can run a single Redis instance for both (the bundled Docker Compose does this) or point each at a different cluster. Each role has its own set of environment variables so they can be configured independently.
+
+#### Sidekiq Redis (job queue)
+
+##### `REDIS_URL`
+
+Lago's Sidekiq workers connect to Redis through the `REDIS_URL` environment variable:
+
+```sh
+REDIS_URL=redis://{host}:{port}/{database}
+```
+
+##### When using the Docker Compose
+
+The bundled `docker-compose.yml` ships a `redis` service. `REDIS_URL=redis://redis:6379` already points at it, so you do not need to override the variable in this setup.
+
+##### Password
+
+If your Redis requires authentication, set the password through a dedicated variable rather than embedding it in the URL:
+
+```sh
+REDIS_PASSWORD=your-redis-password
+```
+
+Keeping the password out of `REDIS_URL` makes it easier to manage secrets separately from non-sensitive connection details.
+
+#### Cache Redis (application cache)
+
+##### `LAGO_REDIS_CACHE_URL`
+
+Lago's API and workers reach the Rails cache through `LAGO_REDIS_CACHE_URL`:
+
+```sh
+LAGO_REDIS_CACHE_URL=redis://{host}:{port}/{database}
+```
+
+You can point this at the same Redis instance as `REDIS_URL`, or at a separate cluster if you want to isolate cache traffic from queue traffic.
+
+##### When using the Docker Compose
+
+The bundled `redis` service is reused for the cache in the default Docker Compose setup. `LAGO_REDIS_CACHE_URL=redis://redis:6379` is pre-configured.
+
+##### Password
+
+Set the cache Redis password through a dedicated variable:
+
+```sh
+LAGO_REDIS_CACHE_PASSWORD=your-cache-redis-password
+```
+
+##### Selecting a database number
+
+When the cache shares a Redis instance with Sidekiq, use a different Redis database number to keep cache keys isolated from queue data:
+
+```sh
+LAGO_REDIS_CACHE_DB=3
+```
+
+Sidekiq uses database `0` by default. The bundled Docker Compose sets the cache to database `3`.
+
+#### Managed Redis services[](#managed-redis-services "Direct link to heading")
+
+Lago works with managed Redis providers (Amazon ElastiCache, Google Cloud Memorystore, Upstash, Redis Enterprise Cloud, etc.) without any extra configuration. These services handle replication, automatic failover, backups, and monitoring on your behalf — you do not need to deploy Sentinel.
+
+Point Lago at the provider's primary endpoint via the standard URL variable. Failover is transparent: when the provider promotes a replica, the endpoint stays the same, and the next reconnect lands on the new master.
+
+##### Amazon ElastiCache
+
+For ElastiCache for Redis in "Cluster Mode Disabled" with replicas, point Lago at the **primary endpoint** (not an individual node endpoint — the primary endpoint follows the active master across failovers):
+
+```sh
+# Sidekiq Redis
+REDIS_URL=rediss://<primary-endpoint>:6379
+REDIS_PASSWORD=<auth-token>
+
+# Cache Redis (can be the same cluster on a different database, or a separate cluster)
+LAGO_REDIS_CACHE_URL=rediss://<primary-endpoint>:6379
+LAGO_REDIS_CACHE_PASSWORD=<auth-token>
+```
+
+The `rediss://` scheme enables in-transit encryption — recommended on ElastiCache and required if you have **Encryption in transit** enabled on the cluster. The password variables carry the AUTH token if AUTH is enabled.
+
+##### Other providers
+
+Google Cloud Memorystore, Upstash, Redis Enterprise Cloud, and similar managed services follow the same pattern: a single endpoint URL and an optional password. Use `rediss://` (or whatever TLS scheme the provider exposes) where supported.
+
+<Info>
+  When using a managed service, **do not** set `LAGO_REDIS_*_SENTINELS`. The Sentinel variables activate self-hosted Sentinel discovery, which managed providers do not expose. Pick one HA mechanism per Redis role — managed service *or* Sentinel, not both.
+</Info>
+
+#### High availability with Sentinel[](#high-availability-with-sentinel "Direct link to heading")
+
+For production deployments that need to survive a Redis master failure, Lago can route both the Sidekiq queue and the cache through [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/). Sentinel is Redis's built-in monitoring layer: a small cluster of Sentinel processes watches the Redis nodes, agrees by quorum when the master is unreachable, and promotes one of the existing replicas. Lago reconnects to the new master automatically — no restart or operator action required.
+
+You can enable Sentinel for the Sidekiq queue, the cache, or both. Each consumer reads its own variables, so mixing modes is supported (for example, Sidekiq through Sentinel and the cache through a static URL).
+
+##### Sidekiq Sentinel configuration
+
+| Variable | Purpose |
+| -------- | ------- |
+| `LAGO_REDIS_SIDEKIQ_SENTINELS` | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for Sidekiq. |
+| `LAGO_REDIS_SIDEKIQ_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional — defaults to `master`. Set this only if your Sentinel cluster uses a different name. |
+
+`REDIS_PASSWORD` continues to authenticate against the underlying data nodes when Sentinel is enabled. You don't need to set `REDIS_URL` when Sentinel mode is active — the master address is discovered dynamically from the Sentinels.
+
+##### Cache Sentinel configuration
+
+| Variable | Purpose |
+| -------- | ------- |
+| `LAGO_REDIS_CACHE_SENTINELS` | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for the cache. |
+| `LAGO_REDIS_CACHE_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional — defaults to `master`. |
+
+`LAGO_REDIS_CACHE_PASSWORD` continues to authenticate against the underlying data nodes when Sentinel is enabled. The cache activates automatically when **either** `LAGO_REDIS_CACHE_URL` or `LAGO_REDIS_CACHE_SENTINELS` is set, so a Sentinel-only deployment with no static URL is supported.
+
+##### Verifying the active master
+
+You can ask any Sentinel for the current master address at any time:
+
+```sh
+redis-cli -h <sentinel-host> -p 26379 SENTINEL get-master-addr-by-name <master_name>
+# 1) "10.0.1.42"
+# 2) "6379"
+```
+
+Use `master` as the master name if you haven't overridden `LAGO_REDIS_SIDEKIQ_MASTER_NAME` or `LAGO_REDIS_CACHE_MASTER_NAME`.
+
+<Warning>
+  When running Sentinel behind a Kubernetes Service, point Lago at the individual Sentinel addresses, not at a Service that fronts the Redis data pods. Sentinel needs to track the actual node identities to detect master failure and promote a replica.
+</Warning>
+
+#### Best practices
+
+- **Bring your own Redis in production.** The bundled `redis` service in `docker-compose.yml` is intended for local trials. For production, run a managed or dedicated Redis (or a Redis cluster fronted by Sentinel) and point Lago at it.
+- **Use separate variables for credentials.** Keep `REDIS_PASSWORD` and `LAGO_REDIS_CACHE_PASSWORD` out of the `*_URL` variables so connection details and secrets can be managed independently.
+- **Enable Sentinel for HA.** A single Redis master is a single point of failure. For production loads with availability requirements, use Sentinel (or a managed Redis service that provides equivalent automatic failover).
+- **Separate cache and queue when in doubt.** Running the cache and Sidekiq on different Redis instances prevents one workload's bursts (heavy queue activity, large cache writes) from impacting the other. Begin with a shared instance and split only if you observe contention.
+- **Encrypt connections.** Use the `rediss://` scheme in `REDIS_URL` / `LAGO_REDIS_CACHE_URL` to enable TLS to your Redis nodes.
+
 ### Components[](#components "Direct link to heading")
 
 Lago uses the following containers:

--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -103,63 +103,65 @@ Docker images are always updated to the last stable version in the
 Lago uses the following environment variables to configure the components of the
 application. You can override them to customise your setup.
 
-| Variable                              | Default value                                  | Description                                                                                                                                                                                                                                                    |
-| ------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `API_PORT`                            | 3000                                           | Port the back-end application listens to                                                                                                                                                                                                                       |
-| `API_URL`                             | [http://localhost:3000](http://localhost:3000) | URL of the Lago back-end application defined for the front image                                                                                                                                                                                               |
-| `DATABASE_POOL`                       | 10                                             | Max number of connection opened to the postgres database per api, worker and clock instances                                                                                                                                                                   |
-| `DATABASE_PREPARED_STATEMENTS`        | true                                           | Enable or disable prepared statements in the postgres database                                                                                                                                                                                                 |
-| `DATABASE_URL`                        |                                                | (_Without docker compose_) Full url to the postgres server                                                                                                                                                                                                     |
-| `FRONT_PORT`                          | 80                                             | Port the front-end application listens to                                                                                                                                                                                                                      |
-| `GOOGLE_AUTH_CLIENT_ID`               |                                                | Client ID for Google auth Single Sign On                                                                                                                                                                                                                       |
-| `GOOGLE_AUTH_CLIENT_SECRET`           |                                                | Client Secret for Google auth Single Sign On                                                                                                                                                                                                                   |
-| `LAGO_API_URL`                        | [http://localhost:3000](http://localhost:3000) | URL of the Lago back-end application                                                                                                                                                                                                                           |
-| `LAGO_AWS_S3_ACCESS_KEY_ID`           | azerty123456                                   | AWS Access Key id that has access to S3                                                                                                                                                                                                                        |
-| `LAGO_AWS_S3_BUCKET`                  | bucket                                         | AWS S3 Bucket name                                                                                                                                                                                                                                             |
-| `LAGO_AWS_S3_ENDPOINT`                |                                                | S3 compatible storage endpoint. Should be set only if you are using another storage provider than AWS S3                                                                                                                                                       |
-| `LAGO_AWS_S3_REGION`                  | us-east-1                                      | AWS S3 Region                                                                                                                                                                                                                                                  |
-| `LAGO_AWS_S3_SECRET_ACCESS_KEY`       | azerty123456                                   | AWS Secret Access Key that has access to S3                                                                                                                                                                                                                    |
-| `LAGO_DATABASE_IDLE_TX_TIMEOUT`       |                                                | A transaction left idle past the time limit (in milliseconds) is terminated. Maps to `idle_in_transaction_session_timeout` in postgres                                                                                                                         |
-| `LAGO_DATABASE_LOCK_TIMEOUT`          |                                                | A statement waiting on a lock past the limit (in milliseconds) fails fast instead of blocking. Maps to `lock_timeout` in postgres                                                                                                                              |
-| `LAGO_DATABASE_STATEMENT_TIMEOUT`     |                                                | Any single query exceeding the time limit (in milliseconds) is cancelled. Maps to `statement_timeout` in postgres                                                                                                                                              |
-| `LAGO_DISABLE_PDF_GENERATION`         | false                                          | Disable automatic PDF generation for invoices, credit notes, and receipts. As a result, the corresponding download endpoints will be unavailable                                                                                                               |
-| `LAGO_DISABLE_SIGNUP`                 |                                                | Disable Sign up when running Lago in self-hosted                                                                                                                                                                                                               |
-| `LAGO_DISABLE_WALLET_REFRESH`         |                                                | Disable automatic refresh of wallet ongoing balance                                                                                                                                                                                                            |
-| `LAGO_ENCRYPTION_DETERMINISTIC_KEY`   | your-encryption-deterministic-key              | Encryption deterministic key used to secure sensitive values stored in the database                                                                                                                                                                            |
-| `LAGO_ENCRYPTION_KEY_DERIVATION_SALT` | your-encryption-derivation-salt                | Encryption key salt used to secure sensitive values stored in the database                                                                                                                                                                                     |
-| `LAGO_ENCRYPTION_PRIMARY_KEY`         | your-encryption-primary-key                    | Encryption primary key used to secure sensitive values stored in the database                                                                                                                                                                                  |
-| `LAGO_FRONT_URL`                      | [http://localhost](http://localhost)           | URL of the Lago front-end application.Used for CORS configuration                                                                                                                                                                                              |
-| `LAGO_GCS_BUCKET`                     |                                                | GCS Bucket Name                                                                                                                                                                                                                                                |
-| `LAGO_GCS_CREDENTIALS`                |                                                | GCS Credentials JSON file path                                                                                                                                                                                                                                 |
-| `LAGO_GCS_GSA_EMAIL`                  |                                                | GCS GSA Email                                                                                                                                                                                                                                                  |
-| `LAGO_GCS_IAM`                        | false                                          | GCS IAM Authentication                                                                                                                                                                                                                                         |
-| `LAGO_GCS_PROJECT`                    |                                                | GCS Project name                                                                                                                                                                                                                                               |
-| `LAGO_MEMCACHE_SERVERS`               |                                                | Comma-separated list of memcache servers                                                                                                                                                                                                                       |
-| `LAGO_PDF_URL`                        | [http://pdf:3000](http://pdf:3000)             | PDF Service URL on your infrastructure                                                                                                                                                                                                                         |
-| `LAGO_RAILS_STDOUT`                   | true                                           | Set to true to activate logs on containers                                                                                                                                                                                                                     |
-| `LAGO_REDIS_CACHE_HOST`               | redis                                          | Host name of the redis cache server                                                                                                                                                                                                                            |
-| `LAGO_REDIS_CACHE_PASSWORD`           |                                                | Password of the redis cache server                                                                                                                                                                                                                             |
-| `LAGO_REDIS_CACHE_POOL_SIZE`          | 5                                              | Max number of connections in the redis cache connection pool                                                                                                                                                                                                   |
-| `LAGO_REDIS_CACHE_PORT`               | 6379                                           | Port the redis cache server listens to                                                                                                                                                                                                                         |
-| `LAGO_REDIS_SIDEKIQ_MASTER_NAME`      | master                                         | Name of the Redis Sentinel master instance. Only used when `LAGO_REDIS_SIDEKIQ_SENTINELS` is set                                                                                                                                                               |
-| `LAGO_REDIS_SIDEKIQ_SENTINELS`        |                                                | Comma-separated list of [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) addresses for Sidekiq high availability (e.g., `sentinel-1:26379,sentinel-2:26379,sentinel-3:26379`). Only applies to Sidekiq, not the cache |
-| `LAGO_RSA_PRIVATE_KEY`                |                                                | Private key used for webhook signatures                                                                                                                                                                                                                        |
-| `LAGO_SIDEKIQ_WEB`                    |                                                | Activate the Sidekiq web UI, disabled by default                                                                                                                                                                                                               |
-| `LAGO_USE_AWS_S3`                     | false                                          | Use AWS S3 for files storage                                                                                                                                                                                                                                   |
-| `LAGO_USE_GCS`                        | false                                          | Use Google Cloud Service Cloud Storage for file storage, ⚠️ If you want to use GCS, you have to pass the credentials json key file to the api and worker service                                                                                                |
-| `LAGO_WEBHOOK_ATTEMPTS`               | 3                                              | Number of failed attempt before stopping to deliver a webhook                                                                                                                                                                                                  |
-| `POSTGRES_DB`                         | lago                                           | (_With Docker compose_) Name of the postgres database                                                                                                                                                                                                          |
-| `POSTGRES_HOST`                       | db                                             | (_With Docker compose_) Host name of the postgres server                                                                                                                                                                                                       |
-| `POSTGRES_PASSWORD`                   | changeme                                       | (_With Docker compose_) Database password for postgres connection                                                                                                                                                                                              |
-| `POSTGRES_PORT`                       | 5432                                           | (_With Docker compose_) Port the postgres database listens to                                                                                                                                                                                                  |
-| `POSTGRES_SCHEMA`                     | public                                         | Name of the postgres schema                                                                                                                                                                                                                                    |
-| `POSTGRES_USER`                       | lago                                           | (_With Docker compose_) Database user for postgres connection                                                                                                                                                                                                  |
-| `REDIS_HOST`                          | redis                                          | Host name of the redis server                                                                                                                                                                                                                                  |
-| `REDIS_PASSWORD`                      |                                                | Password of the redis server                                                                                                                                                                                                                                   |
-| `REDIS_PORT`                          | 6379                                           | Port the redis database listens to                                                                                                                                                                                                                             |
-| `SECRET_KEY_BASE`                     | your-secret-key-base-hex-64                    | Secret key used for session encryption                                                                                                                                                                                                                         |
-| `SENTRY_DSN_FRONT`                    |                                                | Sentry DSN key for error and performance tracking on Lago front-end                                                                                                                                                                                            |
-| `SENTRY_DSN`                          |                                                | Sentry DSN key for error and performance tracking on Lago back-end                                                                                                                                                                                             |
+| Variable                              | Default value                                  | Description                                                                                                                                                                                                                                                        |
+| ------------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `API_PORT`                            | 3000                                           | Port the back-end application listens to                                                                                                                                                                                                                           |
+| `API_URL`                             | [http://localhost:3000](http://localhost:3000) | URL of the Lago back-end application defined for the front image                                                                                                                                                                                                   |
+| `DATABASE_POOL`                       | 10                                             | Max number of connection opened to the postgres database per api, worker and clock instances                                                                                                                                                                       |
+| `DATABASE_PREPARED_STATEMENTS`        | true                                           | Enable or disable prepared statements in the postgres database                                                                                                                                                                                                     |
+| `DATABASE_URL`                        |                                                | (_Without docker compose_) Full url to the postgres server                                                                                                                                                                                                         |
+| `FRONT_PORT`                          | 80                                             | Port the front-end application listens to                                                                                                                                                                                                                          |
+| `GOOGLE_AUTH_CLIENT_ID`               |                                                | Client ID for Google auth Single Sign On                                                                                                                                                                                                                           |
+| `GOOGLE_AUTH_CLIENT_SECRET`           |                                                | Client Secret for Google auth Single Sign On                                                                                                                                                                                                                       |
+| `LAGO_API_URL`                        | [http://localhost:3000](http://localhost:3000) | URL of the Lago back-end application                                                                                                                                                                                                                               |
+| `LAGO_AWS_S3_ACCESS_KEY_ID`           | azerty123456                                   | AWS Access Key id that has access to S3                                                                                                                                                                                                                            |
+| `LAGO_AWS_S3_BUCKET`                  | bucket                                         | AWS S3 Bucket name                                                                                                                                                                                                                                                 |
+| `LAGO_AWS_S3_ENDPOINT`                |                                                | S3 compatible storage endpoint. Should be set only if you are using another storage provider than AWS S3                                                                                                                                                           |
+| `LAGO_AWS_S3_REGION`                  | us-east-1                                      | AWS S3 Region                                                                                                                                                                                                                                                      |
+| `LAGO_AWS_S3_SECRET_ACCESS_KEY`       | azerty123456                                   | AWS Secret Access Key that has access to S3                                                                                                                                                                                                                        |
+| `LAGO_DATABASE_IDLE_TX_TIMEOUT`       |                                                | A transaction left idle past the time limit (in milliseconds) is terminated. Maps to `idle_in_transaction_session_timeout` in postgres                                                                                                                             |
+| `LAGO_DATABASE_LOCK_TIMEOUT`          |                                                | A statement waiting on a lock past the limit (in milliseconds) fails fast instead of blocking. Maps to `lock_timeout` in postgres                                                                                                                                  |
+| `LAGO_DATABASE_STATEMENT_TIMEOUT`     |                                                | Any single query exceeding the time limit (in milliseconds) is cancelled. Maps to `statement_timeout` in postgres                                                                                                                                                  |
+| `LAGO_DISABLE_PDF_GENERATION`         | false                                          | Disable automatic PDF generation for invoices, credit notes, and receipts. As a result, the corresponding download endpoints will be unavailable                                                                                                                   |
+| `LAGO_DISABLE_SIGNUP`                 |                                                | Disable Sign up when running Lago in self-hosted                                                                                                                                                                                                                   |
+| `LAGO_DISABLE_WALLET_REFRESH`         |                                                | Disable automatic refresh of wallet ongoing balance                                                                                                                                                                                                                |
+| `LAGO_ENCRYPTION_DETERMINISTIC_KEY`   | your-encryption-deterministic-key              | Encryption deterministic key used to secure sensitive values stored in the database                                                                                                                                                                                |
+| `LAGO_ENCRYPTION_KEY_DERIVATION_SALT` | your-encryption-derivation-salt                | Encryption key salt used to secure sensitive values stored in the database                                                                                                                                                                                         |
+| `LAGO_ENCRYPTION_PRIMARY_KEY`         | your-encryption-primary-key                    | Encryption primary key used to secure sensitive values stored in the database                                                                                                                                                                                      |
+| `LAGO_FRONT_URL`                      | [http://localhost](http://localhost)           | URL of the Lago front-end application.Used for CORS configuration                                                                                                                                                                                                  |
+| `LAGO_GCS_BUCKET`                     |                                                | GCS Bucket Name                                                                                                                                                                                                                                                    |
+| `LAGO_GCS_CREDENTIALS`                |                                                | GCS Credentials JSON file path                                                                                                                                                                                                                                     |
+| `LAGO_GCS_GSA_EMAIL`                  |                                                | GCS GSA Email                                                                                                                                                                                                                                                      |
+| `LAGO_GCS_IAM`                        | false                                          | GCS IAM Authentication                                                                                                                                                                                                                                             |
+| `LAGO_GCS_PROJECT`                    |                                                | GCS Project name                                                                                                                                                                                                                                                   |
+| `LAGO_MEMCACHE_SERVERS`               |                                                | Comma-separated list of memcache servers                                                                                                                                                                                                                           |
+| `LAGO_PDF_URL`                        | [http://pdf:3000](http://pdf:3000)             | PDF Service URL on your infrastructure                                                                                                                                                                                                                             |
+| `LAGO_RAILS_STDOUT`                   | true                                           | Set to true to activate logs on containers                                                                                                                                                                                                                         |
+| `LAGO_REDIS_CACHE_HOST`               | redis                                          | Host name of the redis cache server. See [Configuring Redis](#configuring-redis).                                                                                                                                                                                  |
+| `LAGO_REDIS_CACHE_MASTER_NAME`        | master                                         | Name of the Redis Sentinel master instance. Only used when `LAGO_REDIS_CACHE_SENTINELS` is set. See [Configuring Redis](#configuring-redis).                                                                                                                       |
+| `LAGO_REDIS_CACHE_PASSWORD`           |                                                | Password of the redis cache server. See [Configuring Redis](#configuring-redis).                                                                                                                                                                                   |
+| `LAGO_REDIS_CACHE_POOL_SIZE`          | 5                                              | Max number of connections in the redis cache connection pool. See [Configuring Redis](#configuring-redis).                                                                                                                                                         |
+| `LAGO_REDIS_CACHE_PORT`               | 6379                                           | Port the redis cache server listens to. See [Configuring Redis](#configuring-redis).                                                                                                                                                                               |
+| `LAGO_REDIS_CACHE_SENTINELS`          |                                                | Comma-separated list of [Redis **Sentinel**](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) addresses for Sidekiq high availability (e.g., `sentinel-1:26379,sentinel-2:26379,sentinel-3:26379`). Only applies to Sidekiq, not the cache |
+| `LAGO_REDIS_SIDEKIQ_MASTER_NAME`      | master                                         | Name of the Redis Sentinel master instance. Only used when `LAGO_REDIS_SIDEKIQ_SENTINELS` is set. See [Configuring Redis](#configuring-redis).                                                                                                                     |
+| `LAGO_REDIS_SIDEKIQ_SENTINELS`        |                                                | Comma-separated list of [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) addresses for Sidekiq high availability (e.g., `sentinel-1:26379,sentinel-2:26379,sentinel-3:26379`). Only applies to Sidekiq, not the cache     |
+| `LAGO_RSA_PRIVATE_KEY`                |                                                | Private key used for webhook signatures                                                                                                                                                                                                                            |
+| `LAGO_SIDEKIQ_WEB`                    |                                                | Activate the Sidekiq web UI, disabled by default                                                                                                                                                                                                                   |
+| `LAGO_USE_AWS_S3`                     | false                                          | Use AWS S3 for files storage                                                                                                                                                                                                                                       |
+| `LAGO_USE_GCS`                        | false                                          | Use Google Cloud Service Cloud Storage for file storage, ⚠️ If you want to use GCS, you have to pass the credentials json key file to the api and worker service                                                                                                    |
+| `LAGO_WEBHOOK_ATTEMPTS`               | 3                                              | Number of failed attempt before stopping to deliver a webhook                                                                                                                                                                                                      |
+| `POSTGRES_DB`                         | lago                                           | (_With Docker compose_) Name of the postgres database                                                                                                                                                                                                              |
+| `POSTGRES_HOST`                       | db                                             | (_With Docker compose_) Host name of the postgres server                                                                                                                                                                                                           |
+| `POSTGRES_PASSWORD`                   | changeme                                       | (_With Docker compose_) Database password for postgres connection                                                                                                                                                                                                  |
+| `POSTGRES_PORT`                       | 5432                                           | (_With Docker compose_) Port the postgres database listens to                                                                                                                                                                                                      |
+| `POSTGRES_SCHEMA`                     | public                                         | Name of the postgres schema                                                                                                                                                                                                                                        |
+| `POSTGRES_USER`                       | lago                                           | (_With Docker compose_) Database user for postgres connection                                                                                                                                                                                                      |
+| `REDIS_HOST`                          | redis                                          | Host name of the redis server                                                                                                                                                                                                                                      |
+| `REDIS_PASSWORD`                      |                                                | Password of the redis server                                                                                                                                                                                                                                       |
+| `REDIS_PORT`                          | 6379                                           | Port the redis database listens to                                                                                                                                                                                                                                 |
+| `SECRET_KEY_BASE`                     | your-secret-key-base-hex-64                    | Secret key used for session encryption                                                                                                                                                                                                                             |
+| `SENTRY_DSN_FRONT`                    |                                                | Sentry DSN key for error and performance tracking on Lago front-end                                                                                                                                                                                                |
+| `SENTRY_DSN`                          |                                                | Sentry DSN key for error and performance tracking on Lago back-end                                                                                                                                                                                                 |
 
 <Warning>
 We recommend that you change `POSTGRES_PASSWORD`, `SECRET_KEY_BASE`,
@@ -173,8 +175,25 @@ improve the security of your Lago instance:
 - `LAGO_ENCRYPTION_PRIMARY_KEY`, `LAGO_ENCRYPTION_DETERMINISTIC_KEY` and
   `LAGO_ENCRYPTION_KEY_DERIVATION_SALT` can all be generated using the
   `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 32 | head -n 1` command.
-
 </Warning>
+
+### Components[](#components "Direct link to heading")
+
+Lago uses the following containers:
+
+| Container    | Role                                                                  |
+| ------------ | --------------------------------------------------------------------- |
+| `front`      | Front-end application                                                 |
+| `api`        | API back-end application                                              |
+| `api_worker` | Asynchronous worker for the API application                           |
+| `api_clock`  | Clock worker for the API application                                  |
+| `db`         | Postgres database engine used to store application data               |
+| `redis`      | Redis database engine used as a queuing system for asynchronous tasks |
+| `pdf`        | PDF generation powered by Gotenberg                                   |
+
+You can also use your own Postgres or Redis server. To do so, remove the `db`
+and `redis` configurations from the `docker-compose.yml` file and update the
+environment variables accordingly.
 
 ### Configuring the database[](#configuring-the-database "Direct link to heading")
 
@@ -299,10 +318,10 @@ For an exhaustive list of SSL parameters, refer to the [libpq documentation](htt
 
 Lago uses Redis for two independent purposes:
 
-- **Job queue** — Sidekiq stores background-job state in Redis. The API enqueues jobs that workers and the clock process pick up.
-- **Application cache** — short-lived computed values (wallet balances, etc.) that the application reads back from `Rails.cache`.
+- **Job queue** - Sidekiq stores background-job state in Redis. The API enqueues jobs that workers and the clock process pick up.
+- **Application cache** - Lago uses Redis as a cache-store for compute-heavy values (current usage, etc.).
 
-You can run a single Redis instance for both (the bundled Docker Compose does this) or point each at a different cluster. Each role has its own set of environment variables so they can be configured independently.
+You can run a single Redis instance for both (the bundled Docker Compose does this) but for a production-ready environment, it is recommended to separate them. Each role has its own set of environment variables so they can be configured independently.
 
 #### Sidekiq Redis (job queue)
 
@@ -313,20 +332,15 @@ Lago's Sidekiq workers connect to Redis through the `REDIS_URL` environment vari
 ```sh
 REDIS_URL=redis://{host}:{port}/{database}
 ```
+```
 
 ##### When using the Docker Compose
 
 The bundled `docker-compose.yml` ships a `redis` service. `REDIS_URL=redis://redis:6379` already points at it, so you do not need to override the variable in this setup.
 
-##### Password
-
-If your Redis requires authentication, set the password through a dedicated variable rather than embedding it in the URL:
-
-```sh
-REDIS_PASSWORD=your-redis-password
 ```
 
-Keeping the password out of `REDIS_URL` makes it easier to manage secrets separately from non-sensitive connection details.
+Keeping the password out of `REDIS_URL` can make it easier to manage secrets separately from non-sensitive connection details.
 
 #### Cache Redis (application cache)
 
@@ -338,125 +352,105 @@ Lago's API and workers reach the Rails cache through `LAGO_REDIS_CACHE_URL`:
 LAGO_REDIS_CACHE_URL=redis://{host}:{port}/{database}
 ```
 
-You can point this at the same Redis instance as `REDIS_URL`, or at a separate cluster if you want to isolate cache traffic from queue traffic.
+You may optionally specify username and password in the URL if your Redis server requires authentication:
+
+```sh
+LAGO_REDIS_CACHE_URL=redis://{user}:{password}@{host}:{port}/{database}
+LAGO_REDIS_CACHE_URL=redis://:{password}@{host}:{port}/{database}
+```
 
 ##### When using the Docker Compose
 
 The bundled `redis` service is reused for the cache in the default Docker Compose setup. `LAGO_REDIS_CACHE_URL=redis://redis:6379` is pre-configured.
 
-##### Password
+#### Authentication
 
-Set the cache Redis password through a dedicated variable:
+It is possible to configure Redis with password-only or ACL-based authentication. In such case, you can configure Lago to authenticate with Redis.
 
-```sh
-LAGO_REDIS_CACHE_PASSWORD=your-cache-redis-password
-```
+##### Sidekiq Redis (job queue)
 
-##### Selecting a database number
-
-When the cache shares a Redis instance with Sidekiq, use a different Redis database number to keep cache keys isolated from queue data:
+If you use password-only authentication, you can set `REDIS_PASSWORD` or include the password in `REDIS_URL`:
 
 ```sh
-LAGO_REDIS_CACHE_DB=3
+REDIS_URL=redis://:{password}@{host}:{port}/{database}
 ```
 
-Sidekiq uses database `0` by default. The bundled Docker Compose sets the cache to database `3`.
+When using ACL-based authentication, you must include the username and password in `REDIS_URL`:
+
+```sh
+REDIS_URL=redis://{user}:{password}@{host}:{port}/{database}
+```
+
+##### Cache Redis (application cache)
+
+If you use password-only authentication, you can set `LAGO_REDIS_CACHE_PASSWORD` or include the password in `LAGO_REDIS_CACHE_URL`:
+
+```sh
+LAGO_REDIS_CACHE_URL=redis://:{password}@{host}:{port}/{database}
+```
+
+When using ACL-based authentication, you must include the username and password in `LAGO_REDIS_CACHE_URL`:
+
+```sh
+LAGO_REDIS_CACHE_URL=redis://{user}:{password}@{host}:{port}/{database}
+```
+
+#### Enabling SSL on Redis
+
+If your Redis server requires SSL connections, you can enable it by using the `rediss://` scheme in your Redis URLs:
+
+```sh
+REDIS_URL=rediss://{host}:{port}/{database}
+LAGO_REDIS_CACHE_URL=rediss://{host}:{port}/{database}
+```
 
 #### Managed Redis services[](#managed-redis-services "Direct link to heading")
 
-Lago works with managed Redis providers (Amazon ElastiCache, Google Cloud Memorystore, Upstash, Redis Enterprise Cloud, etc.) without any extra configuration. These services handle replication, automatic failover, backups, and monitoring on your behalf — you do not need to deploy Sentinel.
+We recommened using Lago with managed Redis providers, such as Amazon ElastiCache. These services handle replication, automatic failover, backups, and monitoring on your behalf, providing a highly available Redis setup with minimal operational overhead.
 
 Point Lago at the provider's primary endpoint via the standard URL variable. Failover is transparent: when the provider promotes a replica, the endpoint stays the same, and the next reconnect lands on the new master.
 
-##### Amazon ElastiCache
+#### High availability with Redis Sentinel[](#high-availability-with-sentinel "Direct link to heading")
 
-For ElastiCache for Redis in "Cluster Mode Disabled" with replicas, point Lago at the **primary endpoint** (not an individual node endpoint — the primary endpoint follows the active master across failovers):
-
-```sh
-# Sidekiq Redis
-REDIS_URL=rediss://<primary-endpoint>:6379
-REDIS_PASSWORD=<auth-token>
-
-# Cache Redis (can be the same cluster on a different database, or a separate cluster)
-LAGO_REDIS_CACHE_URL=rediss://<primary-endpoint>:6379
-LAGO_REDIS_CACHE_PASSWORD=<auth-token>
-```
-
-The `rediss://` scheme enables in-transit encryption — recommended on ElastiCache and required if you have **Encryption in transit** enabled on the cluster. The password variables carry the AUTH token if AUTH is enabled.
-
-##### Other providers
-
-Google Cloud Memorystore, Upstash, Redis Enterprise Cloud, and similar managed services follow the same pattern: a single endpoint URL and an optional password. Use `rediss://` (or whatever TLS scheme the provider exposes) where supported.
-
-<Info>
-  When using a managed service, **do not** set `LAGO_REDIS_*_SENTINELS`. The Sentinel variables activate self-hosted Sentinel discovery, which managed providers do not expose. Pick one HA mechanism per Redis role — managed service *or* Sentinel, not both.
-</Info>
-
-#### High availability with Sentinel[](#high-availability-with-sentinel "Direct link to heading")
-
-For production deployments that need to survive a Redis master failure, Lago can route both the Sidekiq queue and the cache through [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/). Sentinel is Redis's built-in monitoring layer: a small cluster of Sentinel processes watches the Redis nodes, agrees by quorum when the master is unreachable, and promotes one of the existing replicas. Lago reconnects to the new master automatically — no restart or operator action required.
+When using a dedicated Redis setup that you manage yourself, you can achieve high availability with [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/). Sentinel is Redis's built-in monitoring and failover mechanism: a small cluster of Sentinel processes watches the Redis nodes, agrees by quorum when the master is unreachable, and promotes one of the existing replicas. Lago connects to the Sentinels instead of directly to a Redis node, and automatically reconnects to the new master if a failover occurs - no restart or operator action required.
 
 You can enable Sentinel for the Sidekiq queue, the cache, or both. Each consumer reads its own variables, so mixing modes is supported (for example, Sidekiq through Sentinel and the cache through a static URL).
 
+<Warning>
+  Redis also provides high availability through Redis Cluster, but Sidekiq doesn't support it. Sentinel is the only recommended HA solution for self-hosted Lago deployments using dedicated Redis.
+</Warning>
+
+
 ##### Sidekiq Sentinel configuration
 
-| Variable | Purpose |
-| -------- | ------- |
-| `LAGO_REDIS_SIDEKIQ_SENTINELS` | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for Sidekiq. |
-| `LAGO_REDIS_SIDEKIQ_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional — defaults to `master`. Set this only if your Sentinel cluster uses a different name. |
+| Variable                         | Purpose                                                                                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LAGO_REDIS_SIDEKIQ_SENTINELS`   | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for Sidekiq.                   |
+| `LAGO_REDIS_SIDEKIQ_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional - defaults to `master`. Set this only if your Sentinel cluster uses a different name. |
 
-`REDIS_PASSWORD` continues to authenticate against the underlying data nodes when Sentinel is enabled. You don't need to set `REDIS_URL` when Sentinel mode is active — the master address is discovered dynamically from the Sentinels.
+`REDIS_PASSWORD` continues to authenticate against the underlying Redis nodes when Sentinel is enabled.
+You do not need to set `REDIS_URL` when Sentinel mode is enabled. Lago discovers the current Redis master dynamically from `LAGO_REDIS_SIDEKIQ_SENTINELS`.
+
+If `REDIS_URL` is also set, Lago only reuses its connection options, such as the scheme (`redis://` or `rediss://`), password, and database number. The host and port from `REDIS_URL` are ignored because Sentinel provides the active master address.
 
 ##### Cache Sentinel configuration
 
-| Variable | Purpose |
-| -------- | ------- |
-| `LAGO_REDIS_CACHE_SENTINELS` | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for the cache. |
-| `LAGO_REDIS_CACHE_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional — defaults to `master`. |
+| Variable                       | Purpose                                                                                                                     |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `LAGO_REDIS_CACHE_SENTINELS`   | Comma-separated list of Sentinel addresses (`host:port,host:port,...`). Setting this activates Sentinel mode for the cache. |
+| `LAGO_REDIS_CACHE_MASTER_NAME` | The `master_name` declared on the Sentinels. Optional - defaults to `master`.                                               |
 
-`LAGO_REDIS_CACHE_PASSWORD` continues to authenticate against the underlying data nodes when Sentinel is enabled. The cache activates automatically when **either** `LAGO_REDIS_CACHE_URL` or `LAGO_REDIS_CACHE_SENTINELS` is set, so a Sentinel-only deployment with no static URL is supported.
+`REDIS_PASSWORD` continues to authenticate against the underlying Redis nodes when Sentinel is enabled.
+You do not need to set `LAGO_REDIS_CACHE_URL` when Sentinel mode is enabled. Lago discovers the current Redis master dynamically from `LAGO_REDIS_CACHE_SENTINELS`.
 
-##### Verifying the active master
-
-You can ask any Sentinel for the current master address at any time:
-
-```sh
-redis-cli -h <sentinel-host> -p 26379 SENTINEL get-master-addr-by-name <master_name>
-# 1) "10.0.1.42"
-# 2) "6379"
-```
-
-Use `master` as the master name if you haven't overridden `LAGO_REDIS_SIDEKIQ_MASTER_NAME` or `LAGO_REDIS_CACHE_MASTER_NAME`.
-
-<Warning>
-  When running Sentinel behind a Kubernetes Service, point Lago at the individual Sentinel addresses, not at a Service that fronts the Redis data pods. Sentinel needs to track the actual node identities to detect master failure and promote a replica.
-</Warning>
+If `LAGO_REDIS_CACHE_URL` is also set, Lago only reuses its connection options, such as the scheme (`redis://` or `rediss://`), password, and database number. The host and port from `LAGO_REDIS_CACHE_URL` are ignored because Sentinel provides the active master address.
 
 #### Best practices
 
 - **Bring your own Redis in production.** The bundled `redis` service in `docker-compose.yml` is intended for local trials. For production, run a managed or dedicated Redis (or a Redis cluster fronted by Sentinel) and point Lago at it.
-- **Use separate variables for credentials.** Keep `REDIS_PASSWORD` and `LAGO_REDIS_CACHE_PASSWORD` out of the `*_URL` variables so connection details and secrets can be managed independently.
-- **Enable Sentinel for HA.** A single Redis master is a single point of failure. For production loads with availability requirements, use Sentinel (or a managed Redis service that provides equivalent automatic failover).
-- **Separate cache and queue when in doubt.** Running the cache and Sidekiq on different Redis instances prevents one workload's bursts (heavy queue activity, large cache writes) from impacting the other. Begin with a shared instance and split only if you observe contention.
+- **Use separate Redis instances for the cache and the queue in production.** This prevents a surge in one workload (e.g., heavy Sidekiq activity) from impacting the other (e.g., API cache performance). It also allows you to properly configure each Redis instance according to its needs (memory, eviction policy, etc.).
+- **Enable Sentinel or managed instances for HA.** A single Redis master is a single point of failure. For production loads with availability requirements, use Sentinel (or a managed Redis service that provides equivalent automatic failover).
 - **Encrypt connections.** Use the `rediss://` scheme in `REDIS_URL` / `LAGO_REDIS_CACHE_URL` to enable TLS to your Redis nodes.
-
-### Components[](#components "Direct link to heading")
-
-Lago uses the following containers:
-
-| Container    | Role                                                                  |
-| ------------ | --------------------------------------------------------------------- |
-| `front`      | Front-end application                                                 |
-| `api`        | API back-end application                                              |
-| `api_worker` | Asynchronous worker for the API application                           |
-| `api_clock`  | Clock worker for the API application                                  |
-| `db`         | Postgres database engine used to store application data               |
-| `redis`      | Redis database engine used as a queuing system for asynchronous tasks |
-| `pdf`        | PDF generation powered by Gotenberg                                   |
-
-You can also use your own database or Redis server. To do so, remove the `db`
-and `redis` configurations from the `docker-compose.yml` file and update the
-environment variables accordingly.
 
 <a id="ssl-support"></a> { /* Old anchor kept to avoid breaking existing links */ }
 ### Enabling SSL on the Frontend[](#enabling-ssl-on-the-frontend "Direct link to heading")

--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -400,6 +400,8 @@ When using a dedicated Redis setup that you manage yourself, you can achieve hig
 
 You can enable Sentinel for the Sidekiq queue, the cache, or both. Each consumer reads its own variables, so mixing modes is supported (for example, Sidekiq through Sentinel and the cache through a static URL).
 
+If you'd like to use Redis Sentinel, we recommend that you properly read through its documentation and define monitoring and alerting on Sentinel events. Furthermore we suggest to the test failover (e.g., by simulating consecutive master failures) thoroughly and regularly during low-traffic/maintenance periods or on a staging environment to make sure your setup works as expected.
+
 <Warning>
   Redis also provides high availability through Redis Cluster, but Sidekiq doesn't support it. Sentinel is the only recommended HA solution for self-hosted Lago deployments using dedicated Redis.
 </Warning>
@@ -431,9 +433,9 @@ If `LAGO_REDIS_CACHE_URL` is also set, Lago only reuses its connection options, 
 
 #### Best practices
 
-- **Bring your own Redis in production.** The bundled `redis` service in `docker-compose.yml` is intended for local trials. For production, run a managed or dedicated Redis (or a Redis cluster fronted by Sentinel) and point Lago at it.
+- **Bring your own Redis in production.** The bundled `redis` service in `docker-compose.yml` is intended for local trials. For production, run a managed or dedicated Redis (or multiple Redis instance fronted by Sentinel) and point Lago at it.
 - **Use separate Redis instances for the cache and the queue in production.** This prevents a surge in one workload (e.g., heavy Sidekiq activity) from impacting the other (e.g., API cache performance). It also allows you to properly configure each Redis instance according to its needs (memory, eviction policy, etc.).
-- **Enable Sentinel or managed instances for HA.** A single Redis master is a single point of failure. For production loads with availability requirements, use Sentinel (or a managed Redis service that provides equivalent automatic failover).
+- **Use managed instances or Redis Sentinel for HA.** A single Redis master is a single point of failure. For production loads with availability requirements, use Sentinel or a managed Redis service that provides equivalent automatic failover.
 - **Encrypt connections.** Use the `rediss://` scheme in `REDIS_URL` / `LAGO_REDIS_CACHE_URL` to enable TLS to your Redis nodes.
 
 <a id="ssl-support"></a> { /* Old anchor kept to avoid breaking existing links */ }

--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -333,13 +333,7 @@ Lago's Sidekiq workers connect to Redis through the `REDIS_URL` environment vari
 REDIS_URL=redis://{host}:{port}/{database}
 ```
 
-##### When using the Docker Compose
-
-The bundled `docker-compose.yml` ships a `redis` service. `REDIS_URL=redis://redis:6379` already points at it, so you do not need to override the variable in this setup.
-
-```
-
-Keeping the password out of `REDIS_URL` can make it easier to manage secrets separately from non-sensitive connection details.
+When using the Docker Compose, the bundled `docker-compose.yml` ships a `redis` service. `REDIS_URL=redis://redis:6379` already points at it, so you do not need to override the variable in this setup.
 
 #### Cache Redis (application cache)
 
@@ -351,16 +345,7 @@ Lago's API and workers reach the Rails cache through `LAGO_REDIS_CACHE_URL`:
 LAGO_REDIS_CACHE_URL=redis://{host}:{port}/{database}
 ```
 
-You may optionally specify username and password in the URL if your Redis server requires authentication:
-
-```sh
-LAGO_REDIS_CACHE_URL=redis://{user}:{password}@{host}:{port}/{database}
-LAGO_REDIS_CACHE_URL=redis://:{password}@{host}:{port}/{database}
-```
-
-##### When using the Docker Compose
-
-The bundled `redis` service is reused for the cache in the default Docker Compose setup. `LAGO_REDIS_CACHE_URL=redis://redis:6379` is pre-configured.
+When using the Docker Compose, the bundled `redis` service is reused for the cache in the default Docker Compose setup. `LAGO_REDIS_CACHE_URL=redis://redis:6379` is pre-configured.
 
 #### Authentication
 

--- a/guide/lago-self-hosted/docker.mdx
+++ b/guide/lago-self-hosted/docker.mdx
@@ -332,7 +332,6 @@ Lago's Sidekiq workers connect to Redis through the `REDIS_URL` environment vari
 ```sh
 REDIS_URL=redis://{host}:{port}/{database}
 ```
-```
 
 ##### When using the Docker Compose
 


### PR DESCRIPTION
## Context

The self-hosted guide in `guide/lago-self-hosted/docker.mdx` had a thorough "Configuring the database" section, but nothing equivalent for Redis. Operators landing on that page had no documented way to configure the Sidekiq job queue, the application cache, a managed Redis provider, or a self-hosted Sentinel cluster. This adds a parallel "Configuring Redis" section so the Redis side reaches the same level of detail as the database side.

## Description

A new `### Configuring Redis` section was added, mirroring the structure and anchored-heading pattern of "Configuring the database". It is split into the following subsections:

- **Intro.** The two roles Redis plays are described: the Sidekiq job queue and the application cache. A single instance can serve both (as the bundled Docker Compose does), but separating them is recommended for production, and each role has its own variables.
- **Sidekiq Redis (job queue).** Covers `REDIS_URL`, including the bundled `redis://redis:6379` default shipped in `docker-compose.yml`.
- **Cache Redis (application cache).** Covers `LAGO_REDIS_CACHE_URL`, including the pre-configured `redis://redis:6379` default that reuses the bundled service.
- **Authentication.** Documents password-only and ACL-based authentication for both the queue and the cache, showing how to use `REDIS_PASSWORD` / `LAGO_REDIS_CACHE_PASSWORD` or embed credentials directly in the URL.
- **Enabling SSL on Redis.** Shows the `rediss://` scheme for TLS connections on both URLs.
- **Managed Redis services.** Recommends managed providers (Amazon ElastiCache as the example) and explains that Lago points at the provider's primary endpoint, with failover staying transparent because the endpoint is stable across replica promotion.
- **High availability with Redis Sentinel.** Explains what Sentinel is, how failover works, and that it can be enabled for the queue, the cache, or both. Includes a `<Warning>` that Redis Cluster is not supported by Sidekiq, so Sentinel is the recommended HA path. Two config tables document the Sidekiq variables (`LAGO_REDIS_SIDEKIQ_SENTINELS`, `LAGO_REDIS_SIDEKIQ_MASTER_NAME`) and the cache variables (`LAGO_REDIS_CACHE_SENTINELS`, `LAGO_REDIS_CACHE_MASTER_NAME`), and the behavior of `REDIS_PASSWORD` and the URL variables under Sentinel mode is described.
- **Best practices.** Bring your own Redis in production, separate the cache and queue instances, use a managed service or Sentinel for HA, and encrypt connections with `rediss://`.

Supporting changes were made to the rest of the page:

- The environment variables table gained `LAGO_REDIS_CACHE_SENTINELS` and `LAGO_REDIS_CACHE_MASTER_NAME`, and the existing `LAGO_REDIS_CACHE_*` and `LAGO_REDIS_SIDEKIQ_*` rows now link to the new "Configuring Redis" section.
- The "Components" section was moved above "Configuring the database" so the container overview comes before the per-service configuration. Its closing note now reads "your own Postgres or Redis server".

End-user tone is kept throughout: no source-file paths, no internal class names, no Ruby code. Only documented env vars are listed.

## Test plan

- Open `/guide/lago-self-hosted/docker` in the docs preview and confirm the new "Configuring Redis" section renders correctly.
- Verify the table-of-contents anchors link to the right headings and that the `<Warning>` callouts render with the expected styling.
- Confirm the "See Configuring Redis" links in the environment variables table resolve to the new section.
- Read the section as a new self-hoster: pick a topology (single Redis, managed/ElastiCache, Sentinel) and confirm the relevant subsection gives everything needed to set the right env vars.
