### PR TITLE
docs: document usage analytics endpoint and reconciliation

### DIFF
--- a/api-reference/customer-usage/usages.mdx
+++ b/api-reference/customer-usage/usages.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "GET /analytics/usage"
+authMethod: "bearer"
+title: "Retrieve usages"
+description: "Retrieve usages and apply filters to the usage data."
+---

--- a/docs.json
+++ b/docs.json
@@ -440,6 +440,7 @@
                 "group": "Customer usage",
                 "pages": [
                   "api-reference/customer-usage/customer-usage-object",
+                  "api-reference/customer-usage/usages",
                   "api-reference/customer-usage/get-current",
                   "api-reference/customer-usage/get-projected",
                   "api-reference/customer-usage/get-past"

--- a/guide/events/retrieve-usage.mdx
+++ b/guide/events/retrieve-usage.mdx
@@ -146,3 +146,64 @@ Some events can be ingested but trigger unexpected behavior. Lago displays two p
     </CodeGroup>
   </Tab>
 </Tabs>
+
+---
+
+## Retrieve usage analytics
+
+The current, projected, and past usage endpoints above are scoped to a **single subscription**. When you need to look at usage **across customers, plans, or metrics**, or to break consumption down over a **time window**, use the [usage analytics endpoint](../../api-reference/customer-usage/usages) (`GET /analytics/usage`).
+
+This endpoint aggregates the units consumed and the amounts billed, and lets you slice that data with a set of filters. It is the right tool when you want to answer questions like *"how many units did this metric generate per day last month?"* or *"why was this invoice billed the way it was?"*.
+
+<Info>Usage analytics is part of Lago's [analytics layer](../../guide/analytics/reports) and is a premium feature. The same data also powers the analytics dashboards in the UI.</Info>
+
+### Filters
+
+All filters are optional and can be combined. When several filters are set, they are applied together (logical `AND`), progressively narrowing the result set.
+
+| Filter | Type | Description |
+| --- | --- | --- |
+| `time_granularity` | `daily` \| `weekly` \| `monthly` | Splits the result into time buckets at the chosen resolution. See [The date window](#the-date-window) below. |
+| `from_date` | date (`YYYY-MM-DD`) | Start of the period the analytics are computed for. |
+| `to_date` | date (`YYYY-MM-DD`) | End of the period the analytics are computed for. |
+| `currency` | ISO 4217 (e.g. `USD`) | Returns amounts converted to this currency, so usage billed in different currencies can be compared on a single scale. |
+| `external_customer_id` | string | Restricts the analytics to a single customer. |
+| `external_subscription_id` | string | Restricts the analytics to a single subscription. |
+| `plan_code` | string | Restricts the analytics to subscriptions on a given plan. |
+| `billable_metric_code` | string | Restricts the analytics to a single usage-based billable metric. |
+| `is_billable_metric_recurring` | boolean | Keeps only recurring (`true`) or non-recurring (`false`) metrics. |
+| `customer_type` | `individual` \| `company` | Filters by the type of customer. |
+| `customer_country` | ISO 3166-1 alpha-2 (e.g. `US`) | Filters by the customer's billing country. |
+
+Each row of the response carries the period boundaries (`start_of_period_dt`, `end_of_period_dt`), the `billable_metric_code`, the `units` consumed, and the billed `amount_cents` in `amount_currency`.
+
+### The date window
+
+The combination of `from_date`, `to_date`, and `time_granularity` is what makes this endpoint useful for **reconciliation**.
+
+- **`from_date` / `to_date`** define the window the analytics cover. Set them to the start and end of a billing period to look at exactly what a given invoice was computed from.
+- **`time_granularity`** controls how that window is sliced. With `daily`, you get **one row per day per metric**, so you can see the units that accrued each day and the corresponding amount, rather than a single aggregated total.
+
+This daily breakdown is the key to **finding back why a customer was invoiced a given number of units and a given amount**. When an invoice total looks unexpected, query `/analytics/usage` over that invoice's billing period with `time_granularity=daily`, filtered on the relevant `external_subscription_id` and `billable_metric_code`. The day-by-day series shows exactly when consumption spiked, lets you tie each day's units to the amount they generated, and makes it possible to trace the invoiced total back to the underlying daily usage.
+
+<Tip>
+For an invoice you want to explain, set `from_date` and `to_date` to that invoice's billing period boundaries and use `time_granularity=daily`. Summing the daily `units` and `amount_cents` returned reconciles back to the invoiced totals.
+</Tip>
+
+<CodeGroup>
+```bash Retrieve daily usage for reconciliation
+LAGO_URL="https://api.getlago.com"
+API_KEY="__YOUR_API_KEY__"
+EXTERNAL_SUBSCRIPTION_ID="__EXTERNAL_SUBSCRIPTION_ID__"
+BILLABLE_METRIC_CODE="__BILLABLE_METRIC_CODE__"
+
+curl --location --request GET "$LAGO_URL/api/v1/analytics/usage?\
+external_subscription_id=$EXTERNAL_SUBSCRIPTION_ID&\
+billable_metric_code=$BILLABLE_METRIC_CODE&\
+time_granularity=daily&\
+from_date=2023-11-01&\
+to_date=2023-11-30" \
+--header "Authorization: Bearer $API_KEY" \
+--header 'Content-Type: application/json'
+```
+</CodeGroup>


### PR DESCRIPTION
## What

Adds a **Retrieve usage analytics** section to the "Retrieve usage" guide covering the \`GET /analytics/usage\` endpoint, and wires the corresponding API reference page into the navigation.

## Details

- **Guide** ([guide/events/retrieve-usage.mdx](guide/events/retrieve-usage.mdx)): new section that positions usage analytics against the single-subscription current/projected/past endpoints, documents **all filters** (\`time_granularity\`, \`from_date\`/\`to_date\`, \`currency\`, \`external_customer_id\`, \`external_subscription_id\`, \`plan_code\`, \`billable_metric_code\`, \`is_billable_metric_recurring\`, \`customer_type\`, \`customer_country\`), and explains the **date window** in depth — how \`from_date\`/\`to_date\` + \`time_granularity=daily\` lets you fetch daily usage and trace an invoiced total back to the units and amounts that produced it.
- **API reference** (\`api-reference/customer-usage/usages.mdx\`): new OpenAPI-backed page for the endpoint.
- **Navigation** (\`docs.json\`): add the \`usages\` page to the Customer usage group.