### PR TITLE
docs: free credits for recurring target top-ups

### DIFF
--- a/changelog/product.mdx
+++ b/changelog/product.mdx
@@ -6,6 +6,25 @@ rss: "true"
 
 <Update label="May 2026">
 
+  ## Free credits for recurring target top-ups
+
+  <Frame>
+    ![](/changelog/images/20260529-free-target-topup.png)
+  </Frame>
+
+  Recurring **target** top-ups can now refill a wallet with **free credits** instead of paid ones. A target top-up tops the balance back up to a fixed amount on every interval, so this is exactly what you need when customers are granted a set allowance of free credits each period.
+
+  Want every customer to start each month with **$5 of free credits**? Set a monthly target top-up of `5` with free credits, and Lago tops the balance back up to that amount at the start of every month. No manual grants, no paid charge.
+
+  - **Free or paid, your choice**: mark the recurring target top-up as free credits so refills never bill the customer.
+  - **Self-correcting balance**: whatever the customer has left, Lago only adds the difference needed to reach the target.
+  - **Set it once**: define the target and interval when creating or editing the wallet, in the dashboard or via the API.
+
+  Built for teams that hand out a recurring free allowance and want the balance to reset to that number on its own.
+
+  [Learn more](/guide/wallet-and-prepaid-credits/wallet-top-up-and-void#target-recurring-top-up)
+
+
   ## Lago Agent SDK: Bill LLM tokens without middleware
   <Frame>
     ![](/changelog/images/20260519-ai-sdk.png)


### PR DESCRIPTION
## What

Adds a changelog entry documenting that recurring **target** top-ups can now refill a wallet with **free credits** instead of paid ones.

This covers the use case where customers are granted a set free-credit allowance each period (e.g. \$5 of free credits each month) and the balance should reset back to that target on every interval.

## Changes

- New "Free credits for recurring target top-ups" entry at the top of the May 2026 section in `changelog/product.mdx`