### PR TITLE
docs: subscription activation rules (payment-gated activation)

### DIFF
--- a/api-reference/webhooks/messages.mdx
+++ b/api-reference/webhooks/messages.mdx
@@ -298,6 +298,12 @@ description: "Below is a list of the event types we currently send. Please note 
   [Schema example](https://swagger.getlago.com/#/webhooks/feeTaxProviderError)
 </ParamField>
 
+<ParamField path="subscription.incomplete" type="data.object">
+  Sent when a subscription is created in the `incomplete` state, held by an [activation rule](/guide/subscriptions/activation-rules) until its conditions are satisfied (for the payment rule, until the first payment succeeds). While incomplete, no invoice is issued and no usage is billed.
+
+  [Schema example](https://swagger.getlago.com/#/webhooks/subscriptionIncomplete)
+</ParamField>
+
 <ParamField path="subscription.started" type="data.object">
   Sent when a subscription starts. The `previous_plan_code` argument is filled if the subscription has been upgraded or downgraded.
 
@@ -314,6 +320,12 @@ description: "Below is a list of the event types we currently send. Please note 
   Sent when a subscription is terminated. The `next_plan_code` argument is filled if the subscription has been upgraded or downgraded.
 
   [Schema example](https://swagger.getlago.com/#/webhooks/subscriptionTerminated)
+</ParamField>
+
+<ParamField path="subscription.canceled" type="data.object">
+  Sent when an `incomplete` subscription is canceled before it ever activated, because an [activation rule](/guide/subscriptions/activation-rules) could not be satisfied. The `cancellation_reason` field indicates why: `payment_failed` (the payment was declined) or `timeout` (the activation timeout elapsed without a confirmed payment).
+
+  [Schema example](https://swagger.getlago.com/#/webhooks/subscriptionCanceled)
 </ParamField>
 
 <ParamField path="subscription.trial_ended" type="data.object">

--- a/changelog/product.mdx
+++ b/changelog/product.mdx
@@ -6,6 +6,18 @@ rss: "true"
 
 <Update label="June 2026">
 
+  ## Stripe Shared Payment Token: Lago auto-charges invoices through agent payments
+
+  When an AI agent buys on a customer's behalf, there is no card to type into a checkout page. Stripe issues a **Shared Payment Token** instead: a scoped credential the agent grants to you, with built-in usage limits, expiry, and deactivation. Lago now reads that token and charges your invoices against it automatically when they are generated. If the token is valid and within its limits, Stripe resolves it to a real payment method and the charge goes through. No extra step in your billing flow.
+
+  - **Automatic fallback**: the token kicks in only when no other payment method is on file, so existing cards and mandates are never touched.
+  - **Same receipts**: Stripe still issues a real payment method behind the scenes, so `last4`, payment status, and receipts look exactly like a card charge.
+  - **Public preview**: available behind a flag while Stripe rolls the feature out.
+
+  A big thank you to Julien and the Laravel team, who built this contribution.
+
+  [Learn more](/integrations/payments/stripe/shared-payment-tokens)
+
   ## Presentation group keys: break down usages
 
   <Frame>
@@ -1455,7 +1467,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   For card payments processed through integration with Stripe, users can enable the Link option. Link automatically fills the customer's payment information for faster checkout.
 
-  [Learn more](/integrations/payments/stripe-integration#link)
+  [Learn more](/integrations/payments/stripe/payments#link)
 
   <Frame>
     ![](https://uploads-ssl.webflow.com/63569f390f3a7ad4c76d2bd6/669a69858d650ff02d0d8acc_link-stripe.png)
@@ -1689,7 +1701,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
   - ACH Direct Debit for customers with a US bank account
   - BACS Direct Debit for customers with a UK bank account
 
-  [Learn more](/integrations/payments/stripe-integration#supported-payment-methods)
+  [Learn more](/integrations/payments/stripe/payments#supported-payment-methods)
 
   <Frame>
     ![](https://uploads-ssl.webflow.com/63569f390f3a7ad4c76d2bd6/65f00f034ccf549951bebeb6_stripe-ach-bacs.png)
@@ -2166,7 +2178,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   Kindly note, SEPA Direct Debit is only available for invoices denominated in euros (EUR).
 
-  [Learn more](/integrations/payments/stripe-integration#payment-methods)
+  [Learn more](/integrations/payments/stripe/payments#payment-methods)
 
   ## Recurring and prorated charges
 
@@ -2213,7 +2225,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   You can redirect your customer to the corresponding page to register their payment method, which will then be used to collect payment when a new invoice is issued.
 
-  [Learn more](/integrations/payments/stripe-integration#stripe-checkout-storing-customers-payment-method-information)
+  [Learn more](/integrations/payments/stripe/payments#stripe-checkout-storing-customers-payment-method-information)
 
   ## Tax identification number
 
@@ -2799,7 +2811,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
   - Ability to update the status of an invoice depending on the payment status
   - Ability to receive a webhook when a payment fails
 
-  To learn more about this integration, please [consult our guide](/integrations/payments/stripe-integration).
+  To learn more about this integration, please [consult our guide](/integrations/payments/stripe/payments).
 
   ## Weekly plan interval
 

--- a/docs.json
+++ b/docs.json
@@ -175,6 +175,7 @@
                 "group": "Subscriptions",
                 "pages": [
                   "guide/subscriptions/assign-plan",
+                  "guide/subscriptions/activation-rules",
                   "guide/subscriptions/upgrades-downgrades",
                   "guide/subscriptions/edit-subscription",
                   "guide/subscriptions/terminate-subscription"

--- a/docs.json
+++ b/docs.json
@@ -741,7 +741,13 @@
               {
                 "group": "Official integrations",
                 "pages": [
-                  "integrations/payments/stripe-integration",
+                  {
+                    "group": "Stripe",
+                    "pages": [
+                      "integrations/payments/stripe/payments",
+                      "integrations/payments/stripe/shared-payment-tokens"
+                    ]
+                  },
                   "integrations/payments/gocardless-integration",
                   "integrations/payments/adyen-integration",
                   "integrations/usage/segment",
@@ -903,40 +909,36 @@
   },
   "redirects": [
     {
-      "source": "https://docs.getlago.com/guide/alerts",
-      "destination": "https://docs.getlago.com/guide/alerts/usage-alerts"
+      "source": "/integrations/payments/stripe-integration",
+      "destination": "/integrations/payments/stripe/payments"
     },
     {
-      "source": "https://getlago.com/docs/guide/alerts",
-      "destination": "https://getlago.com/docs/guide/alerts/usage-alerts"
+      "source": "/integrations/payments/stripe/stripe-integration",
+      "destination": "/integrations/payments/stripe/payments"
     },
     {
-      "source": "https://docs.getlago.com/api-reference",
-      "destination": "https://docs.getlago.com/api-reference/intro"
+      "source": "/integrations/payments/stripe-shared-payment-token",
+      "destination": "/integrations/payments/stripe/shared-payment-tokens"
     },
     {
-      "source": "https://docs.getlago.com/guide/customers/customer-balance-payment",
-      "destination": "https://docs.getlago.com/guide/dunning/manual-dunning"
+      "source": "/guide/alerts",
+      "destination": "/guide/alerts/usage-alerts"
     },
     {
-      "source": "https://getlago.com/docs/guide/customers/customer-balance-payment",
-      "destination": "https://getlago.com/docs/guide/dunning/manual-dunning"
+      "source": "/api-reference",
+      "destination": "/api-reference/intro"
     },
     {
-      "source": "https://docs.getlago.com/integrations",
-      "destination": "https://docs.getlago.com/integrations/introduction"
+      "source": "/guide/customers/customer-balance-payment",
+      "destination": "/guide/dunning/manual-dunning"
     },
     {
-      "source": "https://getlago.com/docs/integrations",
-      "destination": "https://getlago.com/docs/integrations/introduction"
+      "source": "/integrations",
+      "destination": "/integrations/introduction"
     },
     {
-      "source": "https://docs.getlago.com/guide/events/events-list",
-      "destination": "https://docs.getlago.com/guide/events/retrieve-usage"
-    },
-    {
-      "source": "https://getlago.com/docs/guide/events/events-list",
-      "destination": "https://getlago.com/docs/guide/events/retrieve-usage"
+      "source": "/guide/events/events-list",
+      "destination": "/guide/events/retrieve-usage"
     }
   ],
   "seo": {

--- a/guide/payments/payment-providers.mdx
+++ b/guide/payments/payment-providers.mdx
@@ -67,7 +67,7 @@ Below is the exhaustive list of payment providers natively supported by Lago:
         />
       </svg>
     }
-    href="/integrations/payments/stripe-integration"
+    href="/integrations/payments/stripe/payments"
   >
     Stripe is a suite of APIs powering online payment processing, especially
     card payments.

--- a/guide/subscriptions/activation-rules.mdx
+++ b/guide/subscriptions/activation-rules.mdx
@@ -1,0 +1,142 @@
+---
+title: "Activation rules"
+description: "Hold a subscription in the incomplete state until its activation rules are satisfied. Activation rules are configured per subscription and will expand over time."
+---
+
+Activation rules let you gate when a subscription becomes active. Instead of activating as soon as a plan is assigned, the subscription is held until its rules are satisfied. Rules are opt-in and configured per subscription through the `activation_rules` array, where each rule has a `type`. The set of rule types is designed to grow over time, and each available type is documented in its own section below.
+
+While a subscription is `incomplete`, no invoice is issued and no usage is billed, so access is not granted and no Accounts Receivable (AR) is recorded before its rules are satisfied. Without any activation rule, a subscription becomes active as soon as a plan is assigned and the first invoice is issued immediately. A rule with an unrecognized `type` is rejected.
+
+## How activation rules work
+
+| Mode | How it behaves |
+| ---- | -------------- |
+| **No activation rules** (default) | The subscription is `active` at once and the first invoice is finalized, exactly like a subscription without any gating. |
+| **One or more activation rules** | The subscription starts as `incomplete` and becomes `active` only once every rule is satisfied. If a rule cannot be satisfied, the subscription is `canceled` with a reason. |
+
+A subscription created with activation rules moves through these statuses:
+- `incomplete`: waiting for its rules to be satisfied. No invoice, no billed usage, no access.
+- `active`: every rule is satisfied. From here the subscription behaves like any other active subscription.
+- `canceled`: a rule could not be satisfied. The subscription never activated, and it carries a reason explaining why.
+
+A rule that does not apply to a given subscription resolves as **not applicable** and does not block activation. Each rule's section describes the conditions under which it applies.
+
+## Payment Activation
+
+The `payment` rule activates a subscription only once its first payment succeeds. It keeps the subscription `incomplete` until then. Adding it to `activation_rules` turns on payment gating; leaving `activation_rules` empty keeps the default immediate activation.
+
+### Enable the payment rule
+
+<Tabs>
+  <Tab title="Dashboard">
+    When you assign a plan (or edit, upgrade, or downgrade a subscription):
+    1. In the activation section of the form, choose **"Activate on successful payment"**;
+    2. Set a **timeout** in hours (how long Lago waits for the payment before cancelling the subscription, see [Timeout](#timeout)); and
+    3. Confirm.
+
+    <Info>
+    This option is disabled when the customer has only a manual payment method or no payment provider connected. The payment rule needs a payment method Lago can charge.
+    </Info>
+  </Tab>
+  <Tab title="API">
+    Add an `activation_rules` array to the subscription on `POST /subscriptions`, with a single rule of type `payment`.
+
+    <CodeGroup>
+    ```bash Create a subscription with the payment rule
+    LAGO_URL="https://api.getlago.com"
+    API_KEY="__YOUR_API_KEY__"
+
+    curl --location --request POST "$LAGO_URL/api/v1/subscriptions" \
+    --header "Authorization: Bearer $API_KEY" \
+    --header 'Content-Type: application/json' \
+    --data-raw '{
+      "subscription": {
+        "external_customer_id": "5eb02857-a71e-4ea2-bcf9-57d3a41bc6ba",
+        "plan_code": "premium",
+        "external_id": "my_sub_12345789",
+        "activation_rules": [
+          {
+            "type": "payment",
+            "timeout_hours": 48
+          }
+        ]
+      }
+    }'
+    ```
+    </CodeGroup>
+  </Tab>
+</Tabs>
+
+### Best suited for synchronous card payments
+
+The payment rule works best with **synchronous card payments**, where the charge is approved or declined within seconds, so the subscription activates or cancels right away.
+
+It is riskier with **asynchronous payment methods**, where the result only comes back later, sometimes much later:
+- **Card 3DS authentication:** minutes, but only once the customer completes the challenge;
+- **SEPA / ACH direct debit:** 3 to 7 business days; and
+- **Bank transfer:** whenever the funds actually arrive.
+
+With these methods the subscription can sit `incomplete` for hours or days, and you can't predict how long. During that time the customer has no access and no invoice exists. If the payment never resolves, the subscription only cancels once the timeout is reached. If you do use the payment rule with an async method, set `timeout_hours` to match (see [Timeout](#timeout)).
+
+### Payment lifecycle
+
+With the payment rule set, the subscription follows this flow:
+
+1. **On creation**, the subscription is `incomplete`. No invoice is issued yet: nothing appears in your invoice list and nothing is recorded as AR. No usage is billed yet.
+2. **Payment succeeds** → the subscription becomes `active` and the invoice is generated and finalized: it gets a real number and is recorded as AR, exactly like a normal invoice.
+3. **Payment fails** → the subscription becomes `canceled` (reason: `payment_failed`). No invoice is generated, the customer is not charged, and no AR is recorded.
+4. **Timeout reached** with no confirmed payment → the subscription becomes `canceled` (reason: `timeout`). No invoice is generated.
+
+A canceled subscription is final: it never activated, so there is nothing to resume. **To try again, recreate the subscription with a valid payment method.**
+
+### Timeout
+
+The timeout field sets how long a subscription can stay `incomplete` while waiting for its first payment. If the payment isn't confirmed in time, the subscription is canceled with reason `timeout`.
+
+Set `timeout_hours` to `0` to disable the timeout entirely: the subscription waits indefinitely for the payment to resolve.
+
+<Warning>
+Match the timeout to your payment method. A timeout that is shorter than the payment can realistically take will cancel subscriptions that would have been paid:
+- **Card (3DS):** 1 to 24 hours
+- **SEPA / ACH direct debit:** 168 hours or more (7+ days)
+- **Bank transfer:** 720 hours or more (30+ days)
+</Warning>
+
+### Requirements
+
+- **A payment method is required.** Customers with only a manual payment method, or with no payment provider connected, can't use the payment rule. The request is rejected.
+- **Only the first invoice is gated.** The rule applies to the first invoice created when a subscription is created, upgraded, or downgraded. Renewals, usage-based charges, one-off invoices, and progressive billing invoices are **never** gated: they always use normal billing and [dunning](/guide/dunning/automatic-dunning). A failed renewal never cancels a subscription.
+
+### When the payment rule applies
+
+The payment rule only applies when there is something to pay upfront. Otherwise it resolves as not applicable and the subscription activates immediately, even with the rule set.
+
+| Situation | Result |
+| --------- | ------ |
+| Plan with a pay-in-advance fee, not in trial | **Gated**: incomplete until the first payment succeeds |
+| Plan with pay-in-advance fixed charges | **Gated**: the first invoice covers those charges |
+| Plan paid in arrears, nothing due upfront | Activates immediately (nothing to collect yet) |
+| In a trial with nothing due upfront | Activates immediately |
+| Start date in the past (backdated) | Activates immediately (rules are ignored) |
+| First invoice totals zero (e.g. a 100% coupon) | Activates immediately, invoice finalized normally |
+
+## Editing activation rules
+
+Activation rules can be set or changed while a subscription is `pending` (future-dated). Once a subscription is `active`, `incomplete`, `terminated`, or `canceled`, its rules are read-only.
+
+When you update a subscription, the `activation_rules` field is replace-all:
+- Omitting it (or sending `null`) leaves the existing rules unchanged; and
+- Sending an empty array (`[]`) removes all rules.
+
+## While a subscription is incomplete
+
+- **Manual actions are locked.** You can't edit, upgrade, downgrade, or terminate an `incomplete` subscription. Only the rule outcome moves it out of that state.
+- **Usage is not billed.** Usage events are stored but not billed while the subscription is `incomplete`, and they are not back-billed once it activates.
+
+## Upgrades and downgrades
+
+Activation rules can also gate a plan change. The customer stays on their current plan until the change's rules are satisfied: an upgrade applies as soon as it is satisfied, and a downgrade is gated at the end of the current period. If a rule is not satisfied, the customer stays on their current plan. See [Upgrades and downgrades](/guide/subscriptions/upgrades-downgrades) for how plan changes work.
+
+## Webhooks
+
+A gated subscription emits `subscription.incomplete` when it is created and `subscription.canceled` if it is canceled before activating. When it activates, the usual `subscription.started` and `invoice.created` webhooks fire. See [Subscriptions and fees](/api-reference/webhooks/messages#subscriptions-and-fees) in the webhook messages reference for payloads and details.

--- a/guide/subscriptions/activation-rules.mdx
+++ b/guide/subscriptions/activation-rules.mdx
@@ -3,15 +3,15 @@ title: "Activation rules"
 description: "Hold a subscription in the incomplete state until its activation rules are satisfied. Activation rules are configured per subscription and will expand over time."
 ---
 
-Activation rules let you gate when a subscription becomes active. Instead of activating as soon as a plan is assigned, the subscription is held until its rules are satisfied. Rules are opt-in and configured per subscription through the `activation_rules` array, where each rule has a `type`. The set of rule types is designed to grow over time, and each available type is documented in its own section below.
+Activation rules let you gate when a subscription becomes active. Instead of activating when its start date is reached, the subscription is held until its rules are satisfied. Rules are opt-in and configured per subscription through the `activation_rules` array, where each rule has a `type`. The set of rule types is designed to grow over time, and each available type is documented in its own section below.
 
-While a subscription is `incomplete`, no invoice is issued and no usage is billed, so access is not granted and no Accounts Receivable (AR) is recorded before its rules are satisfied. Without any activation rule, a subscription becomes active as soon as a plan is assigned and the first invoice is issued immediately. A rule with an unrecognized `type` is rejected.
+While a subscription is `incomplete`, no invoice is issued and no usage is billed, so access is not granted and no Accounts Receivable (AR) is recorded before its rules are satisfied. Without any activation rule, a subscription becomes active when its start date is reached. If there is a pay-in-advance fee (subscription or fixed charges), the first invoice is issued at the same time. With nothing due upfront, the subscription activates without an invoice. A rule with an unrecognized `type` is rejected.
 
 ## How activation rules work
 
 | Mode | How it behaves |
 | ---- | -------------- |
-| **No activation rules** (default) | The subscription is `active` at once and the first invoice is finalized, exactly like a subscription without any gating. |
+| **No activation rules** (default) | The subscription becomes `active` when its start date is reached, and the first invoice (if there is anything due upfront) is finalized, exactly like a subscription without any gating. |
 | **One or more activation rules** | The subscription starts as `incomplete` and becomes `active` only once every rule is satisfied. If a rule cannot be satisfied, the subscription is `canceled` with a reason. |
 
 A subscription created with activation rules moves through these statuses:
@@ -94,6 +94,8 @@ A canceled subscription is final: it never activated, so there is nothing to res
 The timeout field sets how long a subscription can stay `incomplete` while waiting for its first payment. If the payment isn't confirmed in time, the subscription is canceled with reason `timeout`.
 
 Set `timeout_hours` to `0` to disable the timeout entirely: the subscription waits indefinitely for the payment to resolve.
+
+When the timeout is reached and the subscription expires, Lago attempts to cancel the pending payment intent. This is best effort: some payment intents can't be canceled, so the payment may still succeed later as a late payment.
 
 <Warning>
 Match the timeout to your payment method. A timeout that is shorter than the payment can realistically take will cancel subscriptions that would have been paid:

--- a/guide/subscriptions/assign-plan.mdx
+++ b/guide/subscriptions/assign-plan.mdx
@@ -48,6 +48,10 @@ When a subscription is active, Lago will automatically generate invoices for the
 The subscription date displayed in the app is based on the organization's timezone.
 </Info>
 
+<Info>
+Want to hold activation until the first payment clears, so you never open AR for an unpaid subscription? See [Activation rules](/guide/subscriptions/activation-rules).
+</Info>
+
 ## Billing cycles
 Optimize billing for your customers by assigning subscriptions based on either calendar dates or anniversary dates (the day they signed up).
 

--- a/guide/subscriptions/terminate-subscription.mdx
+++ b/guide/subscriptions/terminate-subscription.mdx
@@ -5,6 +5,10 @@ description: "You can terminate a subscription at any time, whether it's active 
 
 ## Terminate an active subscription
 
+<Info>
+Subscriptions in the `incomplete` state (held by an [activation rule](/guide/subscriptions/activation-rules)) can't be terminated manually. They cancel on their own if the rule fails or its timeout is reached.
+</Info>
+
 <Tabs>
   <Tab title="Dashboard">
     To terminate an active subscription through the user interface:

--- a/integrations/introduction.mdx
+++ b/integrations/introduction.mdx
@@ -59,7 +59,7 @@ description:
         />
       </svg>
     }
-    href="/integrations/payments/stripe-integration"
+    href="/integrations/payments/stripe/payments"
   >
     Stripe is a suite of APIs powering online payment processing, especially
     card payments.

--- a/integrations/payments/stripe/payments.mdx
+++ b/integrations/payments/stripe/payments.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stripe"
+title: "Payments"
 description:
   "Lago's native integration with Stripe allows you to collect payments
   automatically when new invoices are generated."
@@ -390,6 +390,9 @@ Apple Pay and Google Pay are wallets surfaced by Stripe Checkout on top of the `
     ```
   </Accordion>
 </AccordionGroup>
+
+## Shared Payment Token
+For agent-initiated purchases, where an AI agent pays on the customer's behalf and there is no checkout page, Stripe issues a Shared Payment Token that Lago can collect against automatically. See the [Shared Payment Token guide](/integrations/payments/stripe/shared-payment-tokens).
 
 ## Stripe Checkout: storing customer's payment method information
 <Info>

--- a/integrations/payments/stripe/shared-payment-tokens.mdx
+++ b/integrations/payments/stripe/shared-payment-tokens.mdx
@@ -1,0 +1,93 @@
+---
+title: "Shared Payment Tokens"
+description:
+  "Collect invoice payments for agent-initiated purchases using Stripe's Shared
+  Payment Token."
+---
+
+A Shared Payment Token is a way to get paid when an AI agent buys on a customer's behalf. There is no checkout page and no card for the customer to enter. Stripe issues a scoped token, the agent grants it to you, and Lago collects against it automatically when the invoice is generated.
+
+<Info>
+  Shared Payment Token is in **public preview**. To use it you need two things
+  enabled: the `default_shared_payment_token` feature on your Stripe account
+  (ask your Stripe account representative), and the `stripe_shared_payment_token`
+  flag on your Lago organization ([contact us](mailto:hello@getlago.com) to
+  enable it).
+</Info>
+
+## When to use it
+
+Use a Shared Payment Token for autonomous purchasing flows, where an agent transacts for the customer and the customer never visits a checkout page. The agent already holds permission to pay, within limits the token defines. You just need a way to charge against that permission. For regular card or bank flows, keep using the standard [Stripe payment methods](/integrations/payments/stripe/payments#supported-payment-methods).
+
+## How it works
+
+1. The agent obtains a Shared Payment Token from Stripe. The token is scoped: a currency, a maximum amount, and an expiry date.
+2. The token is attached **directly to the Stripe customer**, on `invoice_settings.default_shared_payment_token`. This happens in Stripe, not in Lago.
+3. When Lago collects a payment, it already retrieves the Stripe customer to check the default payment method. It reads the token from the same call. No extra API request is made.
+4. Stripe processes the payment intent against the token and creates a regular payment method behind the scenes.
+
+## The token is a fallback
+
+Lago uses the Shared Payment Token **only when the customer has no other payment method**. That means:
+
+- no default payment method on `invoice_settings`,
+- no `default_source`, and
+- no saved payment method in the customer's list.
+
+<Warning>
+  If the customer already has a card, a mandate, or any other payment method on
+  file, Lago uses that and ignores the token. The token never overrides an
+  existing payment method.
+</Warning>
+
+## What this preview covers
+
+Lago collects automatically on generated invoices using the token stored on the Stripe customer. The token lives in Stripe, so you set, replace, or remove it there, not through Lago's API or the customer portal. There is no per-payment token parameter in this preview: every invoice for the customer uses the same stored token, as a fallback.
+
+## Setup
+
+1. Ask your Stripe account representative to enable `default_shared_payment_token` on your Stripe account.
+2. [Contact us](mailto:hello@getlago.com) to enable the `stripe_shared_payment_token` flag on your Lago organization.
+3. Connect Stripe in Lago if you have not already ([integration setup](/integrations/payments/stripe/payments#integration-setup)).
+4. Attach the token to the Stripe customer:
+
+```bash
+curl --location --request POST "https://api.stripe.com/v1/customers/cus_123" \
+  --header "Authorization: Bearer $STRIPE_SECRET_KEY" \
+  --data-urlencode "invoice_settings[default_shared_payment_token]=spt_123"
+```
+
+5. That is it. The next invoice with an amount greater than zero is collected against the token automatically.
+
+## Receipts and reconciliation
+
+Behind the scenes Stripe still produces a regular payment method (`pm_...`). Payment status, the card `last4`, and payment receipts behave exactly like a normal card payment. Nothing changes in how you reconcile.
+
+## Token lifecycle
+
+Stripe enforces the token's limits: currency, maximum amount, and expiry. Lago does not validate the token in advance. It reads it at collection time and lets Stripe decide.
+
+A few cases to know:
+
+- **Token expires or hits its limit.** Stripe rejects the payment. It follows Lago's normal [failed-payment handling](/integrations/payments/stripe/payments#failed-payments). Attach a new token to the Stripe customer to resume collection.
+- **Token is revoked.** Same outcome: the next payment fails. Lago does not clear the stored token for you, so replace it in Stripe.
+- **A payment method gets added later.** Lago uses that method on the next invoice and stops using the token, because the token is a fallback.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="What if the customer also has a card on file?" icon="credit-card">
+    Lago uses the card. The token applies only when the customer has no other payment method in Stripe. To collect with the token, make sure no default payment method, default source, or saved payment method is set on the customer.
+  </Accordion>
+  <Accordion title="What happens when the token expires or hits its limit?" icon="clock">
+    Stripe rejects the payment and Lago treats it as a failed payment, with the usual `invoice.payment_failure` webhook and dunning. Attach a new token to the Stripe customer to keep collecting.
+  </Accordion>
+  <Accordion title="Does Lago check the token before using it?" icon="magnifying-glass">
+    No. Lago reads the token at collection time. A missing token means Lago looks for another payment method. An invalid, expired, or exhausted token fails the payment intent.
+  </Accordion>
+  <Accordion title="Do receipts or reconciliation change?" icon="receipt">
+    No. Stripe still creates a real payment method behind the scenes, so payment status, the card `last4`, and payment receipts are identical to a normal card charge.
+  </Accordion>
+</AccordionGroup>
+
+For the full specification, see Stripe's [Shared Payment Tokens documentation](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens).


### PR DESCRIPTION
## What

Documents **subscription activation rules**, starting with the **payment** rule (payment-gated activation): a subscription is held `incomplete` until its first payment succeeds, so you never grant access or record AR for an uncollected payment.

## Changes

- **New guide page** `guide/subscriptions/activation-rules` structured around activation rules as an extensible concept (each rule `type` gets its own H2), with the payment rule as the only type today. Covers the lifecycle, timeout, requirements, when gating applies, and the sync-card vs async-method guidance.
- Added the page to the Subscriptions navigation in `docs.json`.
- Cross-linked it from **Assign a plan** and **Terminate a subscription**.
- Added the `subscription.incomplete` and `subscription.canceled` webhook events to the API webhook messages reference, and deep-linked the guide to that section.

## Note

The `subscription.incomplete` / `subscription.canceled` `[Schema example]` links follow the existing swagger convention and will resolve once those events are added to the OpenAPI spec.