### PR TITLE
docs: add Stripe Shared Payment Token guide and changelog

### DIFF
--- a/changelog/product.mdx
+++ b/changelog/product.mdx
@@ -6,6 +6,18 @@ rss: "true"
 
 <Update label="June 2026">
 
+  ## Stripe Shared Payment Token: Lago auto-charges invoices through agent payments
+
+  When an AI agent buys on a customer's behalf, there is no card to type into a checkout page. Stripe issues a **Shared Payment Token** instead: a scoped credential the agent grants to you, with built-in usage limits, expiry, and deactivation. Lago now reads that token and charges your invoices against it automatically when they are generated. If the token is valid and within its limits, Stripe resolves it to a real payment method and the charge goes through. No extra step in your billing flow.
+
+  - **Automatic fallback**: the token kicks in only when no other payment method is on file, so existing cards and mandates are never touched.
+  - **Same receipts**: Stripe still issues a real payment method behind the scenes, so `last4`, payment status, and receipts look exactly like a card charge.
+  - **Public preview**: available behind a flag while Stripe rolls the feature out.
+
+  A big thank you to Julien and the Laravel team, who built this contribution.
+
+  [Learn more](/integrations/payments/stripe/shared-payment-tokens)
+
   ## Presentation group keys: break down usages
 
   <Frame>
@@ -1455,7 +1467,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   For card payments processed through integration with Stripe, users can enable the Link option. Link automatically fills the customer's payment information for faster checkout.
 
-  [Learn more](/integrations/payments/stripe-integration#link)
+  [Learn more](/integrations/payments/stripe/payments#link)
 
   <Frame>
     ![](https://uploads-ssl.webflow.com/63569f390f3a7ad4c76d2bd6/669a69858d650ff02d0d8acc_link-stripe.png)
@@ -1689,7 +1701,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
   - ACH Direct Debit for customers with a US bank account
   - BACS Direct Debit for customers with a UK bank account
 
-  [Learn more](/integrations/payments/stripe-integration#supported-payment-methods)
+  [Learn more](/integrations/payments/stripe/payments#supported-payment-methods)
 
   <Frame>
     ![](https://uploads-ssl.webflow.com/63569f390f3a7ad4c76d2bd6/65f00f034ccf549951bebeb6_stripe-ach-bacs.png)
@@ -2166,7 +2178,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   Kindly note, SEPA Direct Debit is only available for invoices denominated in euros (EUR).
 
-  [Learn more](/integrations/payments/stripe-integration#payment-methods)
+  [Learn more](/integrations/payments/stripe/payments#payment-methods)
 
   ## Recurring and prorated charges
 
@@ -2213,7 +2225,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
 
   You can redirect your customer to the corresponding page to register their payment method, which will then be used to collect payment when a new invoice is issued.
 
-  [Learn more](/integrations/payments/stripe-integration#stripe-checkout-storing-customers-payment-method-information)
+  [Learn more](/integrations/payments/stripe/payments#stripe-checkout-storing-customers-payment-method-information)
 
   ## Tax identification number
 
@@ -2799,7 +2811,7 @@ Built on the same engine as the [current usage endpoint](../../api-reference/cus
   - Ability to update the status of an invoice depending on the payment status
   - Ability to receive a webhook when a payment fails
 
-  To learn more about this integration, please [consult our guide](/integrations/payments/stripe-integration).
+  To learn more about this integration, please [consult our guide](/integrations/payments/stripe/payments).
 
   ## Weekly plan interval
 

--- a/docs.json
+++ b/docs.json
@@ -740,7 +740,13 @@
               {
                 "group": "Official integrations",
                 "pages": [
-                  "integrations/payments/stripe-integration",
+                  {
+                    "group": "Stripe",
+                    "pages": [
+                      "integrations/payments/stripe/payments",
+                      "integrations/payments/stripe/shared-payment-tokens"
+                    ]
+                  },
                   "integrations/payments/gocardless-integration",
                   "integrations/payments/adyen-integration",
                   "integrations/usage/segment",
@@ -901,6 +907,22 @@
     }
   },
   "redirects": [
+    {
+      "source": "https://docs.getlago.com/integrations/payments/stripe-integration",
+      "destination": "https://docs.getlago.com/integrations/payments/stripe/payments"
+    },
+    {
+      "source": "https://getlago.com/docs/integrations/payments/stripe-integration",
+      "destination": "https://getlago.com/docs/integrations/payments/stripe/payments"
+    },
+    {
+      "source": "https://docs.getlago.com/integrations/payments/stripe-shared-payment-token",
+      "destination": "https://docs.getlago.com/integrations/payments/stripe/shared-payment-tokens"
+    },
+    {
+      "source": "https://getlago.com/docs/integrations/payments/stripe-shared-payment-token",
+      "destination": "https://getlago.com/docs/integrations/payments/stripe/shared-payment-tokens"
+    },
     {
       "source": "https://docs.getlago.com/guide/alerts",
       "destination": "https://docs.getlago.com/guide/alerts/usage-alerts"

--- a/docs.json
+++ b/docs.json
@@ -908,20 +908,16 @@
   },
   "redirects": [
     {
-      "source": "https://docs.getlago.com/integrations/payments/stripe-integration",
-      "destination": "https://docs.getlago.com/integrations/payments/stripe/payments"
+      "source": "/integrations/payments/stripe-integration",
+      "destination": "/integrations/payments/stripe/payments"
     },
     {
-      "source": "https://getlago.com/docs/integrations/payments/stripe-integration",
-      "destination": "https://getlago.com/docs/integrations/payments/stripe/payments"
+      "source": "/integrations/payments/stripe/stripe-integration",
+      "destination": "/integrations/payments/stripe/payments"
     },
     {
-      "source": "https://docs.getlago.com/integrations/payments/stripe-shared-payment-token",
-      "destination": "https://docs.getlago.com/integrations/payments/stripe/shared-payment-tokens"
-    },
-    {
-      "source": "https://getlago.com/docs/integrations/payments/stripe-shared-payment-token",
-      "destination": "https://getlago.com/docs/integrations/payments/stripe/shared-payment-tokens"
+      "source": "/integrations/payments/stripe-shared-payment-token",
+      "destination": "/integrations/payments/stripe/shared-payment-tokens"
     },
     {
       "source": "https://docs.getlago.com/guide/alerts",

--- a/docs.json
+++ b/docs.json
@@ -920,40 +920,24 @@
       "destination": "/integrations/payments/stripe/shared-payment-tokens"
     },
     {
-      "source": "https://docs.getlago.com/guide/alerts",
-      "destination": "https://docs.getlago.com/guide/alerts/usage-alerts"
+      "source": "/guide/alerts",
+      "destination": "/guide/alerts/usage-alerts"
     },
     {
-      "source": "https://getlago.com/docs/guide/alerts",
-      "destination": "https://getlago.com/docs/guide/alerts/usage-alerts"
+      "source": "/api-reference",
+      "destination": "/api-reference/intro"
     },
     {
-      "source": "https://docs.getlago.com/api-reference",
-      "destination": "https://docs.getlago.com/api-reference/intro"
+      "source": "/guide/customers/customer-balance-payment",
+      "destination": "/guide/dunning/manual-dunning"
     },
     {
-      "source": "https://docs.getlago.com/guide/customers/customer-balance-payment",
-      "destination": "https://docs.getlago.com/guide/dunning/manual-dunning"
+      "source": "/integrations",
+      "destination": "/integrations/introduction"
     },
     {
-      "source": "https://getlago.com/docs/guide/customers/customer-balance-payment",
-      "destination": "https://getlago.com/docs/guide/dunning/manual-dunning"
-    },
-    {
-      "source": "https://docs.getlago.com/integrations",
-      "destination": "https://docs.getlago.com/integrations/introduction"
-    },
-    {
-      "source": "https://getlago.com/docs/integrations",
-      "destination": "https://getlago.com/docs/integrations/introduction"
-    },
-    {
-      "source": "https://docs.getlago.com/guide/events/events-list",
-      "destination": "https://docs.getlago.com/guide/events/retrieve-usage"
-    },
-    {
-      "source": "https://getlago.com/docs/guide/events/events-list",
-      "destination": "https://getlago.com/docs/guide/events/retrieve-usage"
+      "source": "/guide/events/events-list",
+      "destination": "/guide/events/retrieve-usage"
     }
   ],
   "seo": {

--- a/guide/payments/payment-providers.mdx
+++ b/guide/payments/payment-providers.mdx
@@ -67,7 +67,7 @@ Below is the exhaustive list of payment providers natively supported by Lago:
         />
       </svg>
     }
-    href="/integrations/payments/stripe-integration"
+    href="/integrations/payments/stripe/payments"
   >
     Stripe is a suite of APIs powering online payment processing, especially
     card payments.

--- a/integrations/introduction.mdx
+++ b/integrations/introduction.mdx
@@ -59,7 +59,7 @@ description:
         />
       </svg>
     }
-    href="/integrations/payments/stripe-integration"
+    href="/integrations/payments/stripe/payments"
   >
     Stripe is a suite of APIs powering online payment processing, especially
     card payments.

--- a/integrations/payments/stripe/payments.mdx
+++ b/integrations/payments/stripe/payments.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Stripe"
+title: "Payments"
 description:
   "Lago's native integration with Stripe allows you to collect payments
   automatically when new invoices are generated."
@@ -390,6 +390,9 @@ Apple Pay and Google Pay are wallets surfaced by Stripe Checkout on top of the `
     ```
   </Accordion>
 </AccordionGroup>
+
+## Shared Payment Token
+For agent-initiated purchases, where an AI agent pays on the customer's behalf and there is no checkout page, Stripe issues a Shared Payment Token that Lago can collect against automatically. See the [Shared Payment Token guide](/integrations/payments/stripe/shared-payment-tokens).
 
 ## Stripe Checkout: storing customer's payment method information
 <Info>

--- a/integrations/payments/stripe/shared-payment-tokens.mdx
+++ b/integrations/payments/stripe/shared-payment-tokens.mdx
@@ -1,0 +1,93 @@
+---
+title: "Shared Payment Tokens"
+description:
+  "Collect invoice payments for agent-initiated purchases using Stripe's Shared
+  Payment Token."
+---
+
+A Shared Payment Token is a way to get paid when an AI agent buys on a customer's behalf. There is no checkout page and no card for the customer to enter. Stripe issues a scoped token, the agent grants it to you, and Lago collects against it automatically when the invoice is generated.
+
+<Info>
+  Shared Payment Token is in **public preview**. To use it you need two things
+  enabled: the `default_shared_payment_token` feature on your Stripe account
+  (ask your Stripe account representative), and the `stripe_shared_payment_token`
+  flag on your Lago organization ([contact us](mailto:hello@getlago.com) to
+  enable it).
+</Info>
+
+## When to use it
+
+Use a Shared Payment Token for autonomous purchasing flows, where an agent transacts for the customer and the customer never visits a checkout page. The agent already holds permission to pay, within limits the token defines. You just need a way to charge against that permission. For regular card or bank flows, keep using the standard [Stripe payment methods](/integrations/payments/stripe/payments#supported-payment-methods).
+
+## How it works
+
+1. The agent obtains a Shared Payment Token from Stripe. The token is scoped: a currency, a maximum amount, and an expiry date.
+2. The token is attached **directly to the Stripe customer**, on `invoice_settings.default_shared_payment_token`. This happens in Stripe, not in Lago.
+3. When Lago collects a payment, it already retrieves the Stripe customer to check the default payment method. It reads the token from the same call. No extra API request is made.
+4. Stripe processes the payment intent against the token and creates a regular payment method behind the scenes.
+
+## The token is a fallback
+
+Lago uses the Shared Payment Token **only when the customer has no other payment method**. That means:
+
+- no default payment method on `invoice_settings`,
+- no `default_source`, and
+- no saved payment method in the customer's list.
+
+<Warning>
+  If the customer already has a card, a mandate, or any other payment method on
+  file, Lago uses that and ignores the token. The token never overrides an
+  existing payment method.
+</Warning>
+
+## What this preview covers
+
+Lago collects automatically on generated invoices using the token stored on the Stripe customer. The token lives in Stripe, so you set, replace, or remove it there, not through Lago's API or the customer portal. There is no per-payment token parameter in this preview: every invoice for the customer uses the same stored token, as a fallback.
+
+## Setup
+
+1. Ask your Stripe account representative to enable `default_shared_payment_token` on your Stripe account.
+2. [Contact us](mailto:hello@getlago.com) to enable the `stripe_shared_payment_token` flag on your Lago organization.
+3. Connect Stripe in Lago if you have not already ([integration setup](/integrations/payments/stripe/payments#integration-setup)).
+4. Attach the token to the Stripe customer:
+
+```bash
+curl --location --request POST "https://api.stripe.com/v1/customers/cus_123" \
+  --header "Authorization: Bearer $STRIPE_SECRET_KEY" \
+  --data-urlencode "invoice_settings[default_shared_payment_token]=spt_123"
+```
+
+5. That is it. The next invoice with an amount greater than zero is collected against the token automatically.
+
+## Receipts and reconciliation
+
+Behind the scenes Stripe still produces a regular payment method (`pm_...`). Payment status, the card `last4`, and payment receipts behave exactly like a normal card payment. Nothing changes in how you reconcile.
+
+## Token lifecycle
+
+Stripe enforces the token's limits: currency, maximum amount, and expiry. Lago does not validate the token in advance. It reads it at collection time and lets Stripe decide.
+
+A few cases to know:
+
+- **Token expires or hits its limit.** Stripe rejects the payment. It follows Lago's normal [failed-payment handling](/integrations/payments/stripe/payments#failed-payments). Attach a new token to the Stripe customer to resume collection.
+- **Token is revoked.** Same outcome: the next payment fails. Lago does not clear the stored token for you, so replace it in Stripe.
+- **A payment method gets added later.** Lago uses that method on the next invoice and stops using the token, because the token is a fallback.
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="What if the customer also has a card on file?" icon="credit-card">
+    Lago uses the card. The token applies only when the customer has no other payment method in Stripe. To collect with the token, make sure no default payment method, default source, or saved payment method is set on the customer.
+  </Accordion>
+  <Accordion title="What happens when the token expires or hits its limit?" icon="clock">
+    Stripe rejects the payment and Lago treats it as a failed payment, with the usual `invoice.payment_failure` webhook and dunning. Attach a new token to the Stripe customer to keep collecting.
+  </Accordion>
+  <Accordion title="Does Lago check the token before using it?" icon="magnifying-glass">
+    No. Lago reads the token at collection time. A missing token means Lago looks for another payment method. An invalid, expired, or exhausted token fails the payment intent.
+  </Accordion>
+  <Accordion title="Do receipts or reconciliation change?" icon="receipt">
+    No. Stripe still creates a real payment method behind the scenes, so payment status, the card `last4`, and payment receipts are identical to a normal card charge.
+  </Accordion>
+</AccordionGroup>
+
+For the full specification, see Stripe's [Shared Payment Tokens documentation](https://docs.stripe.com/agentic-commerce/concepts/shared-payment-tokens).


### PR DESCRIPTION
## What

Documents Stripe Shared Payment Token support for agent-initiated payments, based on [getlago/lago-api#5567](https://github.com/getlago/lago-api/pull/5567).

## Changes

- **New guide**: `integrations/payments/stripe/shared-payment-tokens.mdx` explaining what the feature is, when to use it, how it works, the fallback behavior, setup, token lifecycle, and an FAQ.
- **Navigation**: groups the Stripe pages under a new **Stripe** folder with two links, **Payments** and **Shared Payment Token**. The former `stripe-integration` page moves to `stripe/payments`.
- **Redirects**: added for both moved pages across both doc domains so existing links keep working.
- **Cross-links**: the Stripe Payments page now points to the Shared Payment Token guide; in-repo links updated to the new paths.
- **Changelog**: a product entry announcing the feature, crediting the contribution from Julien and the Laravel team.

## Notes

- The feature is in public preview and gated behind the `stripe_shared_payment_token` organization flag.
- The token is used only as a fallback, when the customer has no other payment method on file.