### PR TITLE
docs: add Polytomic (ETL) community data integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -771,6 +771,7 @@
                 "group": "Community integrations",
                 "pages": [
                   "integrations/data/airbyte",
+                  "integrations/data/polytomic",
                   "integrations/payments/cashfree-integration",
                   "integrations/payments/moneyhash-integration",
                   "integrations/entitlements/osohq",

--- a/integrations/data/polytomic.mdx
+++ b/integrations/data/polytomic.mdx
@@ -1,0 +1,23 @@
+---
+title: "Polytomic (ETL)"
+---
+
+Polytomic is a **data movement platform** used as an ETL. With this integration, you can sync Lago billing data to your warehouses, databases, SaaS tools, spreadsheets, and webhooks, without writing code.
+
+## Destinations
+You can push Lago billing data to destinations such as Snowflake, BigQuery, Redshift or Databricks. Polytomic also supports many other databases, SaaS applications, spreadsheets, cloud storage and APIs.
+The entire list of destinations is available in their [destinations documentation](https://docs.polytomic.com/).
+
+## 1. Connect Lago to Polytomic
+First, bring your Lago private API key. In Polytomic:
+- Go to **Connections**;
+- Add Lago as a source of data; and
+- Paste your Lago private API key.
+
+## 2. Select a destination
+Pick any destination available in Polytomic. It could be a warehouse (Snowflake, BigQuery, Redshift, Databricks...) or another system such as a database or SaaS tool.
+
+## 3. Sync billing data
+Create a **sync** between your Lago source and your destination, define a **schedule**, then activate it. Polytomic supports both real-time and scheduled syncs. This populates your Lago billing data into the destination.
+
+Find the full documentation of [Polytomic's Lago integration](https://www.polytomic.com/integrations/lago).

--- a/integrations/introduction.mdx
+++ b/integrations/introduction.mdx
@@ -790,6 +790,38 @@ description:
     <br />
     <Tooltip tip="This integration is community-maintained, and therefore Lago provides only limited support.">Community</Tooltip>
   </Card>
+  <Card
+    title="Polytomic (ETL)"
+    icon={
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 32 32"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect width="32" height="32" rx="8" fill="#19212E" />
+        <g transform="translate(4 4) scale(0.75)">
+          <path
+            fillRule="evenodd"
+            clipRule="evenodd"
+            d="M16 1.70491L29.5225 28.75H2.47742L16 1.70491ZM6.5225 26.25H25.4774L16 7.29508L6.5225 26.25Z"
+            fill="#0BD9A5"
+          />
+          <circle cx="16" cy="4.5" r="4.5" fill="#0BD9A5" />
+          <ellipse cx="4.5" cy="27.5" rx="4.5" ry="4.5" fill="#0BD9A5" />
+          <ellipse cx="27.5" cy="27.5" rx="4.5" ry="4.5" fill="#0BD9A5" />
+        </g>
+      </svg>
+    }
+    href="/integrations/data/polytomic"
+  >
+    Sync billing data to your warehouses, databases and SaaS tools by using our
+    integration with Polytomic.
+
+    <br />
+    <Tooltip tip="This integration is community-maintained, and therefore Lago provides only limited support.">Community</Tooltip>
+  </Card>
 </CardGroup>
 
 ## Entitlements integrations


### PR DESCRIPTION
Adds Polytomic as a community-maintained data integration source.

- New page `integrations/data/polytomic.mdx` framing Polytomic as an ETL that syncs Lago billing data to warehouses (Snowflake, BigQuery, Redshift, Databricks), databases and SaaS tools.
- Registered in the "Community integrations" group in `docs.json`, alongside Airbyte.
- Added a Polytomic card to the Data integrations section in `integrations/introduction.mdx`, using Polytomic's own brand mark and a Community tooltip.