### PR TITLE
docs: cache-bust openapi spec URL to force Mintlify re-ingest (BIL-104)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -870,7 +870,7 @@
     "dark": "/logo/dark.svg"
   },
   "api": {
-    "openapi": "https://swagger.getlago.com/openapi.yaml",
+    "openapi": "https://swagger.getlago.com/openapi.yaml?v=2026-06-09",
     "mdx": {
       "server": "https://api.getlago.com/api/v1"
     }


### PR DESCRIPTION
Fixing BIL-104 : billing period should not appear on the get list end point