### PR TITLE
docs(events): clarify batch atomicity and indexed 422 errors

### DIFF
--- a/api-reference/events/batch.mdx
+++ b/api-reference/events/batch.mdx
@@ -4,6 +4,8 @@ authMethod: "bearer"
 title: "Batch usage events"
 ---
 
+Batches are atomic. If a single event is invalid, Lago rejects the entire batch with a `422` and persists nothing, including the valid events in the same request. "Invalid" covers a bad schema, an unknown subscription, or a duplicate `transaction_id` (`value_already_exist`). The `error_details` object reports failures by the event's index in the array you sent, not by `transaction_id`, so keep your array order to trace an index back to its source event.
+
 <RequestExample>
 
 ```bash cURL
@@ -139,3 +141,22 @@ func main() {
 ```
 
 </RequestExample>
+
+<ResponseExample>
+
+```json Batch rejected (422)
+{
+  "status": 422,
+  "error": "Unprocessable Entity",
+  "code": "validation_errors",
+  "error_details": {
+    "1": {
+      "transaction_id": [
+        "value_already_exist"
+      ]
+    }
+  }
+}
+```
+
+</ResponseExample>

--- a/guide/events/ingesting-usage.mdx
+++ b/guide/events/ingesting-usage.mdx
@@ -404,7 +404,7 @@ For the full list of available ingestion sources, see [Metering ingestion source
     ```
 
     <Warning>
-      If any event within the batch does not meet the structural requirements, the entire batch will be rejected. Verify the structure of each event before batching.
+      **Batches are atomic.** If a single event is invalid, Lago rejects the entire batch with a `422` and persists nothing. The valid events in the same request are dropped too. "Invalid" covers a bad schema, an unknown subscription, or a duplicate `transaction_id` (`value_already_exist`). The response reports failures by the event's **index in the array you sent**, not by `transaction_id`. Keep your array order so you can trace an index back to its source event. Validate and de-duplicate before batching.
     </Warning>
   </Tab>
 </Tabs>
@@ -626,7 +626,7 @@ Design your IDs to be **deterministic** (derived from source data), not random. 
 
   <Accordion title="Correcting events">
     - With Postgres: duplicates are rejected with 422 (no replacement). Use a new `transaction_id` to correct.
-    - With ClickHouse: to amend a previously sent event, send a new event with the same `transaction_id` and `timestamp` with the updated properties. The new event will replaces the original.
+    - With ClickHouse: to amend a previously sent event, send a new event with the same `transaction_id` and `timestamp` with the updated properties. The new event replaces the original.
   </Accordion>
 
   <Accordion title="Events before subscription start">


### PR DESCRIPTION
## What

Makes the all-or-nothing behavior of `POST /events/batch` explicit in both the ingestion guide and the API reference.

## Why

The endpoint's rejection behavior was described vaguely. The only mention of failure was a single warning about "structural requirements," which undersold the real contract and left two things unsaid that bite users in production:

- **Atomicity is broader than schema validation.** Any invalid event rejects the whole batch with a `422`, including a duplicate `transaction_id` (`value_already_exist`). On rejection nothing is persisted, including the valid events in the same call.
- **Errors are reported by array index, not `transaction_id`.** You map the returned index back to the position in the array you sent. The `transaction_id` value is not echoed back.

The API reference page also showed only request examples, so a developer integrating against it had no way to learn the error shape from the spec.

## Changes

- `guide/events/ingesting-usage.mdx`: expanded the batch `Warning` into a full statement of the atomic contract. Fixed an adjacent "will replaces" typo.
- `api-reference/events/batch.mdx`: added a prose note on atomicity plus a `ResponseExample` showing the indexed `422` (`error_details` keyed by array position).