### PR TITLE
docs: add Rate limits page to API Reference

### DIFF
--- a/api-reference/errors.mdx
+++ b/api-reference/errors.mdx
@@ -194,6 +194,15 @@ For some 4xx errors, the response body will include additional information to he
 { "status": 429, "error": "Too Many Provider Requests", "code": "too_many_provider_requests", "error_details": { "provider_name": "[provider_name]", "message": "[message]" } }
 ```
 
+This error is returned when a downstream payment or tax provider rate-limits Lago. It is distinct from the platform rate limit below.
+
+### rate_limited
+```
+HTTP/1.1 429 Too Many Requests
+```
+
+Returned when you exceed the REST API rate limit for your organization. The response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers. See [Rate limits](/api-reference/rate-limits) for the limits and retry guidance.
+
 ### internal_server_error
 ```json
 { "status": 500, "errors": [{ "message": "[error_message]", "backtrace": [backtrace] }], "data": {} }

--- a/api-reference/rate-limits.mdx
+++ b/api-reference/rate-limits.mdx
@@ -6,7 +6,8 @@ Lago enforces rate limits on the REST API per organization to protect platform s
 
 | Endpoint category | Default limit |
 | --- | --- |
-| **Event ingestion** (`POST /events`, `POST /events/batch`) | 500 requests/sec |
+| **Event ingestion** (`POST /events`) | 500 requests/sec |
+| **Batch event ingestion** (`POST /events/batch`) | 50 requests/sec |
 | **Current usage** | 200 requests/sec |
 | **All other endpoints** | 50 requests/sec |
 

--- a/api-reference/rate-limits.mdx
+++ b/api-reference/rate-limits.mdx
@@ -1,0 +1,27 @@
+---
+title: "Rate limits"
+---
+
+Lago enforces rate limits on the REST API per organization to protect platform stability. Default limits are shown below, and they can be raised to match your needs. Contact the Lago team if you need higher throughput.
+
+| Endpoint category | Default limit |
+| --- | --- |
+| **Event ingestion** (`POST /events`, `POST /events/batch`) | 500 requests/sec |
+| **Current usage** | 200 requests/sec |
+| **All other endpoints** | 50 requests/sec |
+
+Rate limits apply per organization, so all of your API keys share the same budget.
+
+## When you are rate limited
+
+You receive a `429 Too Many Requests` response. Every response includes headers to help you manage your rate:
+
+- `X-RateLimit-Limit`: maximum requests for the current window
+- `X-RateLimit-Remaining`: requests left in the current window
+- `X-RateLimit-Reset`: seconds until the window resets
+
+Retrying after a `429` is safe. Event ingestion is deduplicated by `transaction_id`, so a replayed event is never billed twice. Back off until `X-RateLimit-Reset` reaches zero before retrying.
+
+<Info>
+  Kafka, Kinesis, and S3 connectors are not subject to REST API rate limits. Their throughput is bounded by your broker or infrastructure capacity.
+</Info>

--- a/api-reference/rate-limits.mdx
+++ b/api-reference/rate-limits.mdx
@@ -7,7 +7,6 @@ Lago enforces rate limits on the REST API per organization to protect platform s
 | Endpoint category | Default limit |
 | --- | --- |
 | **Event ingestion** (`POST /events`) | 500 requests/sec |
-| **Batch event ingestion** (`POST /events/batch`) | 50 requests/sec |
 | **Current usage** | 200 requests/sec |
 | **All other endpoints** | 50 requests/sec |
 

--- a/docs.json
+++ b/docs.json
@@ -342,7 +342,8 @@
                   "api-reference/intro",
                   "api-reference/api-standards",
                   "api-reference/errors",
-                  "api-reference/pagination"
+                  "api-reference/pagination",
+                  "api-reference/rate-limits"
                 ]
               },
               {

--- a/faq/general.mdx
+++ b/faq/general.mdx
@@ -29,7 +29,7 @@ Chargebee is not designed for usage-based billing. Lago is.
 
 Lago is designed for usage-based pricing models, providing a high level of flexibility and support complex usage-based scenarios. Chargebee supports standard usage-based models (e.g. $20 per user) but may not be flexible enough for businesses that need support for complex usage-based pricing models (e.g., PayPal's per-transaction pricing). Chargebee limits the maximum number of usages that can be recorded for a subscription is 5,000, over its lifetime. 
 
-Lago has no rate limit for usage-based billing events, allowing for high volume processing. Chargebee has a rate limit of 100 simultaneous requests per minute, which could prevent you from sending granular usage when you start scaling your number of customers. 
+Lago is built for high-volume event ingestion, with generous default rate limits that can be raised on request. Chargebee has a rate limit of 100 simultaneous requests per minute, which could prevent you from sending granular usage when you start scaling your number of customers. 
 Additionally, Lago, being an open source solution, offers complete transparency, allowing engineers to audit its code and even build on top of it, which Chargebee does not allow. 
 
 ## 5. Is Lago cheaper than Chargebee?

--- a/guide/events/ingesting-usage.mdx
+++ b/guide/events/ingesting-usage.mdx
@@ -653,20 +653,7 @@ Design your IDs to be **deterministic** (derived from source data), not random. 
 
 ## Rate limits
 
-Lago enforces rate limits on the REST API per organization to protect platform stability. Default limits are shown below — these can be adjusted to match your needs. Contact the Lago team if you need higher throughput.
-
-| Endpoint category | Default limit |
-| --- | --- |
-| **Event ingestion** (`POST /events`, `POST /events/batch`) | 500 requests/sec |
-| **Current usage** | 200 requests/sec |
-| **All other endpoints** | 50 requests/sec |
-
-**When rate limited:** You receive a `429 Too Many Requests` response. Every response includes headers to help you manage your rate:
-- `x-ratelimit-limit` — max requests per window
-- `x-ratelimit-remaining` — remaining requests
-- `x-ratelimit-reset` — seconds until the window resets
-
-Retries on `429` are always safe thanks to `transaction_id` deduplication. Back off until `x-ratelimit-reset` reaches zero.
+Lago enforces per-organization rate limits on the REST API, with the highest limits on event ingestion. If you exceed them you receive a `429 Too Many Requests` response with `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers. Retrying after a `429` is safe thanks to `transaction_id` deduplication. See [Rate limits](/api-reference/rate-limits) for the full limits and retry guidance.
 
 <Info>
   Kafka, Kinesis, and S3 connectors are not subject to REST API rate limits. Their throughput is bounded by your broker or infrastructure capacity.


### PR DESCRIPTION
- Add api-reference/rate-limits.mdx as the canonical rate-limits reference
- Register it in docs.json under Getting started
- Document the platform 429 on the Errors page, distinct from the provider 429
- Reword the FAQ so it no longer claims no rate limit on usage events
- Point the ingesting-usage guide at the canonical page to avoid drift