### PR TITLE
docs: document updating fixed charges via plan_overrides

### DIFF
--- a/guide/plans/charges/fixed-charges.mdx
+++ b/guide/plans/charges/fixed-charges.mdx
@@ -47,6 +47,56 @@ This gives you control over whether changes impact current or future billing.
   Customers will receive an invoice reflecting this update.
 </Info>
 
+### Update a fixed charge via the API[](#update-fixed-charge-api "Direct link to heading")
+To update a fixed charge on a subscription, pass it under the [`plan_overrides`](/guide/subscriptions/assign-plan#overriding-a-plan) object when you create or update the subscription.
+
+How you update it changes the outcome:
+- Pass **only** `units` (and `apply_units_immediately` if needed) to change the quantity. This does **not** create a plan override.
+- Pass any other field, such as a price or `properties`, and Lago **creates a plan override**.
+
+This request updates the units only. It does not create a plan override:
+
+```json Update units only (no override)
+{
+  "subscription": {
+    "plan_overrides": {
+      "fixed_charges": [
+        {
+          "id": "af360881-357a-4334-ad16-8cd38e246d03",
+          "units": 20,
+          "apply_units_immediately": true
+        }
+      ]
+    }
+  }
+}
+```
+
+This request creates a plan override, because it changes the price:
+
+```json Update price (creates an override)
+{
+  "subscription": {
+    "plan_overrides": {
+      "fixed_charges": [
+        {
+          "id": "af360881-357a-4334-ad16-8cd38e246d03",
+          "units": 20,
+          "properties": {
+            "amount": "30"
+          },
+          "apply_units_immediately": true
+        }
+      ]
+    }
+  }
+}
+```
+
+<Info>
+  Send only `units` to change the quantity without creating an override. Any other field creates one.
+</Info>
+
 ## Delete a fixed charge[](#delete-fixed-charge "Direct link to heading")
 You can delete a fixed-charge even if the plan is associated to active [subscriptions](/guide/subscriptions/assign-plan).
 

--- a/guide/subscriptions/assign-plan.mdx
+++ b/guide/subscriptions/assign-plan.mdx
@@ -286,6 +286,13 @@ This enables you to maintain a consistent plan structure for all customers while
               "group_properties": [],
               "taxes": []
             }
+          ],
+          "fixed_charges": [
+            {
+              "id": "af360881-357a-4334-ad16-8cd38e246d03",
+              "units": 20,
+              "apply_units_immediately": true
+            }
           ]
         }
       }
@@ -294,6 +301,10 @@ This enables you to maintain a consistent plan structure for all customers while
     </CodeGroup>
   </Tab>
 </Tabs>
+
+<Info>
+  Fixed charges are also overridden under `plan_overrides`, using the `fixed_charges` array. Sending only `units` (and `apply_units_immediately` if needed) updates the quantity without creating a plan override. Passing a price or `properties` creates one. See [Update a fixed charge via the API](/guide/plans/charges/fixed-charges#update-fixed-charge-api).
+</Info>
 
 It's crucial to note that all overridden plans will remain associated with the initial plan but won't be visible in the plans list. 
 To access an overridden plan, simply click on the specific subscription item in the customer details view.

--- a/guide/subscriptions/edit-subscription.mdx
+++ b/guide/subscriptions/edit-subscription.mdx
@@ -41,6 +41,13 @@ Once a plan has been assigned to a customer, whether it's in a pending or active
               },
               "group_properties": [],
             }
+          ],
+          "fixed_charges": [
+            {
+              "id": "af360881-357a-4334-ad16-8cd38e246d03",
+              "units": 20,
+              "apply_units_immediately": true
+            }
           ]
         }
       }
@@ -49,3 +56,7 @@ Once a plan has been assigned to a customer, whether it's in a pending or active
     </CodeGroup>
   </Tab>
 </Tabs>
+
+<Info>
+  Fixed charges are updated under `plan_overrides`, using the `fixed_charges` array. Sending only `units` (and `apply_units_immediately` if needed) updates the quantity without creating a plan override. Passing a price or `properties` creates one. See [Update a fixed charge via the API](/guide/plans/charges/fixed-charges#update-fixed-charge-api).
+</Info>


### PR DESCRIPTION
## What

Documents the improved behavior for updating a fixed charge on a subscription.

- To update a fixed charge, pass it under the `plan_overrides` object.
- Passing **only** `units` (and `apply_units_immediately` if needed) updates the quantity **without** creating a plan override.
- Passing any other field (a price or `properties`) **creates** a plan override.

## Changes

- `guide/plans/charges/fixed-charges.mdx` — new "Update a fixed charge via the API" section with both JSON examples (units-only vs. price) and a callout summarizing the rule. This is the single source of truth.
- `guide/subscriptions/assign-plan.mdx` — added the `fixed_charges` array to the override example and a note cross-linking to the fixed-charges guide.
- `guide/subscriptions/edit-subscription.mdx` — mirrored the `fixed_charges` example and cross-link in the PUT example.