### PR TITLE
Chore: cap invoice metadata value at 140 and note customer name limit

### DIFF
--- a/guide/customers/customer-management.mdx
+++ b/guide/customers/customer-management.mdx
@@ -3,6 +3,10 @@ title: "Customer management"
 ---
 
 ## Create and update a customer[](#create-and-update-a-customer "Direct link to heading")
+
+<Note>
+The customer's name is limited to 255 characters.
+</Note>
 <Tabs>
   <Tab title="Dashboard">
       To create a customer through the user interface:

--- a/guide/invoicing/invoice-metadata.mdx
+++ b/guide/invoicing/invoice-metadata.mdx
@@ -50,4 +50,4 @@ When editing invoice metadata through the API, please make sure to include the e
 
 1. You can add up to 5 metadata key-value pairs;
 2. Keys must be strings of 20 characters maximum; and
-3. Values must be strings of 255 characters maximum.
+3. Values must be strings of 140 characters maximum.


### PR DESCRIPTION
Align docs with the length limits enforced on the API side (getlago/lago-api#5880):
- invoice metadata value: 255 -> 140 characters max
- customer name: note the 255-character limit