### PR TITLE
docs(wallets): document customer-scoped wallet endpoints

### DIFF
--- a/api-reference/wallets/create-for-customer.mdx
+++ b/api-reference/wallets/create-for-customer.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "POST /customers/{external_customer_id}/wallets"
+authMethod: "bearer"
+title: "Create a wallet for a customer"
+description: "This endpoint is used to create a wallet with prepaid credits, scoped to a customer identified by its external ID."
+---

--- a/api-reference/wallets/get-all-for-customer.mdx
+++ b/api-reference/wallets/get-all-for-customer.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "GET /customers/{external_customer_id}/wallets"
+authMethod: "bearer"
+title: "List all wallets for a customer"
+description: "This endpoint is used to list all wallets with prepaid credits belonging to a customer, identified by its external ID."
+---

--- a/api-reference/wallets/get-specific-by-code.mdx
+++ b/api-reference/wallets/get-specific-by-code.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "GET /customers/{external_customer_id}/wallets/{code}"
+authMethod: "bearer"
+title: "Retrieve a wallet by code"
+description: "This endpoint is used to retrieve a single wallet, identified by the customer's external ID and the wallet code. The code is unique per customer."
+---

--- a/api-reference/wallets/terminate-by-code.mdx
+++ b/api-reference/wallets/terminate-by-code.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "DELETE /customers/{external_customer_id}/wallets/{code}"
+authMethod: "bearer"
+title: "Terminate a wallet by code"
+description: "This endpoint is used to terminate an existing wallet, identified by the customer's external ID and the wallet code."
+---

--- a/api-reference/wallets/update-by-code.mdx
+++ b/api-reference/wallets/update-by-code.mdx
@@ -1,0 +1,6 @@
+---
+openapi: "PUT /customers/{external_customer_id}/wallets/{code}"
+authMethod: "bearer"
+title: "Update a wallet by code"
+description: "This endpoint is used to update an existing wallet, identified by the customer's external ID and the wallet code."
+---

--- a/docs.json
+++ b/docs.json
@@ -687,6 +687,16 @@
                   "api-reference/wallets/get-specific",
                   "api-reference/wallets/get-all",
                   {
+                    "group": "Wallets by code",
+                    "pages": [
+                      "api-reference/wallets/create-for-customer",
+                      "api-reference/wallets/update-by-code",
+                      "api-reference/wallets/terminate-by-code",
+                      "api-reference/wallets/get-specific-by-code",
+                      "api-reference/wallets/get-all-for-customer"
+                    ]
+                  },
+                  {
                     "group": "Wallet transactions",
                     "pages": [
                       "api-reference/wallets/wallet-transaction-object",


### PR DESCRIPTION
## Context

A support ticket surfaced that there's no documented way to retrieve a wallet by its **code** — users assumed the only option was the top-level `lago_id`-based endpoints and had to page through all wallets and filter client-side.

Investigating the codebase and specs showed the capability **already exists**:
- The API supports the customer-scoped wallet endpoints (`app/controllers/api/v1/customers/wallets_controller.rb`).
- The OpenAPI spec (`swagger.getlago.com/openapi.yaml`) fully defines them, e.g. `GET /customers/{external_customer_id}/wallets/{code}` (`operationId: findCustomerWallet`).

But the **API reference never surfaced them** — the Wallets section only listed the top-level `/wallets` and `/wallets/{lago_id}` pages. It was also internally inconsistent: the wallet **alert** pages already use the nested `/customers/{external_customer_id}/wallets/{wallet_code}/...` paths, so codes-in-URL were shown for alerts but not for the wallet resource itself.

## Description

Adds API-reference pages for the five customer-scoped wallet endpoints and groups them under **"Wallets by code"** in the navigation, so the code-based workflow is discoverable:

| Page | Endpoint |
|---|---|
| Retrieve a wallet by code | `GET /customers/{external_customer_id}/wallets/{code}` |
| List all wallets for a customer | `GET /customers/{external_customer_id}/wallets` |
| Create a wallet for a customer | `POST /customers/{external_customer_id}/wallets` |
| Update a wallet by code | `PUT /customers/{external_customer_id}/wallets/{code}` |
| Terminate a wallet by code | `DELETE /customers/{external_customer_id}/wallets/{code}` |

Pages use the same spec-driven, frontmatter-only style as the existing nested wallet-alert pages (Mintlify auto-generates request/response examples from the spec). No existing pages or endpoints were changed — additive only.

## Notes for reviewers

- **Group naming / placement**: I used "Wallets by code". You may prefer different wording, or to position the code-based pages as the *primary* set over the `lago_id` ones.
- **SDK coverage**: I deliberately avoided hand-writing SDK snippets since the language clients may not yet expose customer-scoped wallet methods — worth confirming separately (that's a client gap, not a docs one).
- Validated locally: `docs.json` is valid JSON, all pages are wired into nav, and every `openapi:` path resolves against the live spec Mintlify fetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)