### PR TITLE
docs: warn that refunding prepaid credits can re-trigger a threshold top-up

### DIFF
--- a/guide/invoicing/credit-notes/overview.mdx
+++ b/guide/invoicing/credit-notes/overview.mdx
@@ -46,7 +46,7 @@ Prepaid credit invoices follow specific rules:
 <Warning>
   Refunding a prepaid credit invoice voids the corresponding credits from the wallet, which lowers its ongoing balance. If the wallet has an active [threshold-based recurring top-up](/guide/wallet-and-prepaid-credits/wallet-top-up-and-void#threshold-trigger), this drop can fall below the threshold and automatically trigger a new paid top-up, generating a new invoice and a new charge through the connected payment provider.
 
-  Before refunding prepaid credits, disable the wallet's threshold-based top-up rule. Terminate the wallet afterward if it is no longer needed.
+  Before refunding prepaid credits, disable the wallet's threshold-based top-up rule.
 </Warning>
 
 ## Issue a credit note

--- a/guide/invoicing/credit-notes/overview.mdx
+++ b/guide/invoicing/credit-notes/overview.mdx
@@ -43,6 +43,12 @@ Prepaid credit invoices follow specific rules:
 - **If a payment is recorded:** You can refund the available wallet balance. This immediately voids the credits from the wallet.
 - **If no payment is recorded:** You can only offset the invoice. The wallet transaction is not settled and the wallet balance remains unchanged.
 
+<Warning>
+  Refunding a prepaid credit invoice voids the corresponding credits from the wallet, which lowers its ongoing balance. If the wallet has an active [threshold-based recurring top-up](/guide/wallet-and-prepaid-credits/wallet-top-up-and-void#threshold-trigger), this drop can fall below the threshold and automatically trigger a new paid top-up, generating a new invoice and a new charge through the connected payment provider.
+
+  Before refunding prepaid credits, disable the wallet's threshold-based top-up rule. Terminate the wallet afterward if it is no longer needed.
+</Warning>
+
 ## Issue a credit note
 
 <Tabs>

--- a/guide/invoicing/credit-notes/overview.mdx
+++ b/guide/invoicing/credit-notes/overview.mdx
@@ -45,8 +45,6 @@ Prepaid credit invoices follow specific rules:
 
 <Warning>
   Refunding a prepaid credit invoice voids the corresponding credits from the wallet, which lowers its ongoing balance. If the wallet has an active [threshold-based recurring top-up](/guide/wallet-and-prepaid-credits/wallet-top-up-and-void#threshold-trigger), this drop can fall below the threshold and automatically trigger a new paid top-up, generating a new invoice and a new charge through the connected payment provider.
-
-  Before refunding prepaid credits, disable the wallet's threshold-based top-up rule.
 </Warning>
 
 ## Issue a credit note


### PR DESCRIPTION
What changed

Adds a warning to the prepaid-credit refund section of the credit notes guide: refunding a prepaid credit invoice voids the wallet credits, which lowers the ongoing balance and can auto-fire an active threshold-based top-up rule (new invoice + payment-provider charge).

Why

A customer following the documented refund procedure hit a loop of Stripe charges: each refund credit note dropped the wallet below its threshold, re-firing the top-up rule. Verified in code (CreditNotes::CreateService#handle_refund -> WalletTransactions::VoidService -> Wallets::Balance::UpdateOngoingService -> Wallets::ThresholdTopUpService).

Impact

Docs-only. No behavior change.

Closes Pylon #6112

🤖 Generated with [Claude Code](https://claude.com/claude-code)