### PR TITLE
docs(webhooks): add invoice.ready_to_finalize to webhook messages

### DIFF
--- a/api-reference/webhooks/messages.mdx
+++ b/api-reference/webhooks/messages.mdx
@@ -159,6 +159,12 @@ description: "Below is a list of the event types we currently send. Please note 
   [Schema example](https://swagger.getlago.com/#/webhooks/invoiceDrafted)
 </ParamField>
 
+<ParamField path="invoice.ready_to_finalize" type="data.object">
+  Sent when a draft invoice is ready to be finalized, meaning taxes are resolved. This event is sent when the draft invoice is created if no tax provider call is pending, or once the tax provider has returned taxes for the draft invoice.
+
+  [Schema example](https://swagger.getlago.com/#/webhooks/invoiceReadyToFinalize)
+</ParamField>
+
 <ParamField path="invoice.created" type="data.object">
   Sent when an invoice is finalized. This event serves as a signal to your application that the invoice processing is complete and you can proceed with the necessary billing actions or procedures.
 


### PR DESCRIPTION
Adds the `invoice.ready_to_finalize` webhook to the [webhook messages page](https://docs.getlago.com/api-reference/webhooks/messages), where it was missing.

This event exists in lago-api (`Webhooks::Invoices::ReadyToFinalizeService`): it signals that a draft invoice is ready to be finalized (taxes are resolved). It fires either when the draft is created and no tax provider call is pending, or once the tax provider has returned taxes for the draft invoice.

The schema example link points to the corresponding OpenAPI entry added in getlago/lago-openapi#565 (`invoiceReadyToFinalize`), so that PR should merge first for the link to resolve.